### PR TITLE
implement fill value for points outside of data bounds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       run: |
         apt-get update && apt-get install -y build-essential
         python -m pip install --upgrade pip
-        pip install --no-build-isolation .[test]
+        pip install --no-build-isolation .[test,viz]
         python setup.py build_ext --inplace
     - name: Run tests
       run: make unittest


### PR DESCRIPTION
this is useful when the physical domain of the target grid is larger than the input data. For example, when regridding a regional simulation onto a global lat lon grid.