### PR TITLE
Project name from earth2-grid to earth2grid

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=40.8.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "earth2-grid"
+name = "earth2grid"
 version = "2024.8.1"
 description = "Utilities for working with geographic data defined on various grids."
 readme = "README.md"
@@ -31,7 +31,7 @@ dependencies = [
 ]
 
 [project.urls]
-"Homepage" = "https://github.com/waynerv/earth2-grid"
+"Homepage" = "https://github.com/NVlabs/earth2grid"
 
 
 [project.optional-dependencies]


### PR DESCRIPTION
Consistency between package name and the repo name will make installing this package slightly more straightforward. Also fixed URL.