### PR TITLE
Fixing backward pass in CUDA padding backend

### DIFF
--- a/earth2grid/healpix/_padding/cuda.py
+++ b/earth2grid/healpix/_padding/cuda.py
@@ -42,7 +42,7 @@ class _HEALPixPadFunction(torch.autograd.Function):
         -------
         torch.tensor: The padded tensor
         """
-        # ctx.pad = pad
+        ctx.pad = pad
         if input.ndim != 5:
             raise ValueError(
                 f"Input tensor must be have 5 dimensions (B, F, C, H, W), got {len(input.shape)} dimensions instead"

--- a/tests/test_healpix_padding.py
+++ b/tests/test_healpix_padding.py
@@ -100,5 +100,3 @@ def test_healpix_pad(backend, device):
     out.mean().backward()
     assert out.shape == (n, ntile, nside + padding * 2, nside + padding * 2)
     assert x.grad.shape == (n, ntile, nside, nside)
-
-

--- a/tests/test_healpix_padding.py
+++ b/tests/test_healpix_padding.py
@@ -60,35 +60,45 @@ def test_hpx_pad_versus_zephyr(tmp_path):
         fig, axs = plt.subplots(3, 12, figsize=(20, 5))
         for i in range(12):
             # Plot expected values
-            axs[0, i].imshow(expected[0, i].cpu(), cmap='viridis')
-            axs[0, i].set_title(f'Expected Face {i}')
-            axs[0, i].axis('off')
+            axs[0, i].imshow(expected[0, i].cpu(), cmap="viridis")
+            axs[0, i].set_title(f"Expected Face {i}")
+            axs[0, i].axis("off")
 
             # Plot actual values
-            axs[1, i].imshow(ans[0, i].cpu(), cmap='viridis')
-            axs[1, i].set_title(f'Actual Face {i}')
-            axs[1, i].axis('off')
+            axs[1, i].imshow(ans[0, i].cpu(), cmap="viridis")
+            axs[1, i].set_title(f"Actual Face {i}")
+            axs[1, i].axis("off")
 
             # Plot difference
             diff = expected[0, i].cpu() - ans[0, i].cpu()
-            axs[2, i].imshow(diff, cmap='RdBu')
-            axs[2, i].set_title(f'Diff Face {i}')
-            axs[2, i].axis('off')
+            axs[2, i].imshow(diff, cmap="RdBu")
+            axs[2, i].set_title(f"Diff Face {i}")
+            axs[2, i].axis("off")
 
         plt.tight_layout(pad=1.0)
-        fig_path = tmp_path / 'healpix_padding_comparison.png'
-        plt.savefig(fig_path, dpi=300, bbox_inches='tight')
+        fig_path = tmp_path / "healpix_padding_comparison.png"
+        plt.savefig(fig_path, dpi=300, bbox_inches="tight")
         plt.close()
         raise AssertionError(f"Padding results differ between backends. Check the saved visualization {fig_path}")
 
 
 @pytest.mark.parametrize("backend", list(PaddingBackends))
-def test_healpix_pad(backend):
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+def test_healpix_pad(backend, device):
+    if not torch.cuda.is_available() and device == "cuda":
+        pytest.skip("CUDA not available.")
+    if backend == PaddingBackends.cuda and device == "cpu":
+        pytest.skip("CUDA padding backend not supported on CPU")
+
     ntile = 12
     nside = 32
     padding = 1
     n = 3
-    x = torch.ones([n, ntile, nside, nside])
+    x = torch.ones([n, ntile, nside, nside], device=device, requires_grad=True)
     with pad_backend(backend):
         out = pad(x, padding=padding)
+    out.mean().backward()
     assert out.shape == (n, ntile, nside + padding * 2, nside + padding * 2)
+    assert x.grad.shape == (n, ntile, nside, nside)
+
+


### PR DESCRIPTION
A small fix for issue I ran into using the CUDA healpix padding backend with the backwards pass:
```bash
# python model_perf.py 
Traceback (most recent call last):
  File "/home/asubramaniam/Codes/edm-chaos/datasets/icon_cycle_3/model_perf.py", line 75, in <module>
    loss.backward()
  File "/usr/local/lib/python3.12/dist-packages/torch/_tensor.py", line 581, in backward
    torch.autograd.backward(
  File "/usr/local/lib/python3.12/dist-packages/torch/autograd/__init__.py", line 347, in backward
    _engine_run_backward(
  File "/usr/local/lib/python3.12/dist-packages/torch/autograd/graph.py", line 825, in _engine_run_backward
    return Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/autograd/function.py", line 307, in apply
    return user_fn(self, *args)
           ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/earth2grid/healpix/_padding/cuda.py", line 80, in backward
    pad = ctx.pad
          ^^^^^^^
AttributeError: '_HEALPixPadFunctionBackward' object has no attribute 'pad'
```