### PR TITLE
Added cuda channels last forward and backwards

### DIFF
--- a/earth2grid/csrc/healpixpad/cudamacro.h
+++ b/earth2grid/csrc/healpixpad/cudamacro.h
@@ -2,7 +2,7 @@
  * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Written by Mauro Bisson <maurob@nvidia.com> and THorsten Kurth <tkurth@nvidia.com>
+ * Written by Mauro Bisson <maurob@nvidia.com> and Thorsten Kurth <tkurth@nvidia.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/earth2grid/csrc/healpixpad/healpixpad_cuda.cpp
+++ b/earth2grid/csrc/healpixpad/healpixpad_cuda.cpp
@@ -2,7 +2,7 @@
  * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Written by Mauro Bisson <maurob@nvidia.com> and THorsten Kurth <tkurth@nvidia.com>
+ * Written by Mauro Bisson <maurob@nvidia.com> and Thorsten Kurth <tkurth@nvidia.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,11 +24,11 @@
 // CUDA forward declarations
 std::vector<torch::Tensor> healpixpad_cuda_forward(
 						   torch::Tensor input,
-						   int pad);
+						   const int pad, const bool channels_last);
 
 std::vector<torch::Tensor> healpixpad_cuda_backward(
 						   torch::Tensor grad_input,
-						   int pad);
+						   const int pad, const bool channels_last);
 
 // C++ interface
 #define CHECK_CUDA(x) TORCH_CHECK(x.device().is_cuda(), #x " must be a CUDA tensor")
@@ -37,37 +37,47 @@ std::vector<torch::Tensor> healpixpad_cuda_backward(
 
 std::vector<torch::Tensor> healpixpad_forward(
 					      torch::Tensor input,
-					      int pad){
+					      const int pad, const bool channels_last){
   CHECK_INPUT(input);
+  assert (pad >= 0);
   assert (input.dims() == 5);
   assert (input.size(1) == 12);
-  assert (input.size(3) == input.size(4));
   assert (input.size(3) % 2 == 0);
-  assert (pad >= 0);
   assert (pad < int(input.size(3)));
+
+  if (!channels_last) {
+    assert (input.size(3) == input.size(4));
+  } else {
+    assert (input.size(2) == input.size(3));
+  }
 
   if (pad == 0) {
     return {input};
   } else {
-    return healpixpad_cuda_forward(input, pad);
+    return healpixpad_cuda_forward(input, pad, channels_last);
   }
 }
 
 std::vector<torch::Tensor> healpixpad_backward(
 					       torch::Tensor ginput,
-					       int pad){
+					       const int pad, const bool channels_last){
   CHECK_INPUT(ginput);
   assert (ginput.dims() == 5);
   assert (ginput.size(1) == 12);
-  assert (ginput.size(3) == ginput.size(4));
   assert (ginput.size(3) % 2 == 0);
   assert (pad >= 0);
   assert (pad < int(ginput.size(3)));
 
+  if (!channels_last) {
+    assert (ginput.size(3) == ginput.size(4));
+  } else {
+    assert (ginput.size(2) == ginput.size(3));
+  }
+
   if (pad ==0) {
     return {ginput};
   } else {
-    return healpixpad_cuda_backward(ginput, pad);
+    return healpixpad_cuda_backward(ginput, pad, channels_last);
   }
 }
 

--- a/earth2grid/csrc/healpixpad/healpixpad_cuda_bwd.cu
+++ b/earth2grid/csrc/healpixpad/healpixpad_cuda_bwd.cu
@@ -2,7 +2,7 @@
  * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Written by Mauro Bisson <maurob@nvidia.com> and THorsten Kurth <tkurth@nvidia.com>
+ * Written by Mauro Bisson <maurob@nvidia.com> and Thorsten Kurth <tkurth@nvidia.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,9 +27,6 @@
 
 #define THREADS  64
 
-#define MIN(x,y) (((x)<(y))?(x):(y))
-#define MAX(x,y) (((x)>(y))?(x):(y))
-
 #define DIV_UP(a,b) (((a)+((b)-1))/(b))
 
 // All coordinates are w.r.t. a face[dimK][dimL][dimM]:
@@ -50,16 +47,17 @@
 //
 // Along the k-axis, dimJ=12 faces form a "sphere" and
 // we have in total dimI sphere in the buffers
-
-template<typename VAL_T>
-__global__ void HEALPixPadBck_bulk_k(const int padSize,
+template<typename VAL_T, bool CHANNELS_LAST>
+__global__ void HEALPixPadBck_bulk_vec_k(const int padSize,
 				     const int dimI,
 				     const int dimJ,
 				     const int dimK,
 				     const int dimL,
 				     const int dimM,
-				     const VAL_T *__restrict__ vin,
-				     VAL_T *__restrict__ vout) {
+				     const torch::PackedTensorAccessor32<VAL_T, 5, torch::RestrictPtrTraits> vin,
+             torch::PackedTensorAccessor32<VAL_T, 5, torch::RestrictPtrTraits> vout) {
+  using VecT = typename VecTraits<VAL_T>::VecT;
+  constexpr int W = VecTraits<VAL_T>::LANE_WIDTH;
 
   const long long tid = ((long long)blockIdx.x)*blockDim.x + threadIdx.x;
 
@@ -67,62 +65,86 @@ __global__ void HEALPixPadBck_bulk_k(const int padSize,
     return;
   }
 
-  const long long sliceId = tid / (dimM*dimL);
+  const int dimKVec = CHANNELS_LAST ? dimK / W : dimK;
+  const int dimMVec = CHANNELS_LAST ? dimM : dimM / W;
 
-  const int i = (tid % (dimM*dimL)) / dimM;
-  const int j = (tid % (dimM*dimL)) % dimM;
+  // compute individual indices
+  int i,j,k,l,m;
+  if constexpr(CHANNELS_LAST) {
+    k = (tid % dimKVec) * W;
+    m = (tid / dimKVec) % dimM;
+    l = (tid / (dimKVec * dimM)) % dimL;
+    j = (tid / (dimKVec * dimM * dimL)) % dimJ;
+    i =  tid / (dimKVec * dimM * dimL * dimJ);
+  } else {
+    m = (tid % dimMVec) * W;
+    l = (tid / dimMVec) % dimL;
+    k = (tid / (dimMVec * dimL)) % dimK;
+    j = (tid / (dimMVec * dimL * dimK)) % dimJ;
+    i =  tid / (dimMVec * dimL * dimK * dimJ);
+  }
 
-  const int dimLI = dimL + 2*padSize;
-  const int dimMI = dimM + 2*padSize;
+  VecT* dstVec = reinterpret_cast<VecT*>(
+        &getElemMutable<VAL_T,CHANNELS_LAST>(vout,i,j,k,l,m));
 
-  vout[sliceId*dimM*dimL + i*dimM + j] = vin[sliceId*dimLI*dimMI + (padSize+i)*dimMI + padSize+j];
+  if (!CHANNELS_LAST && ((padSize & (W - 1)) != 0)) {
+    // Load unvectorized as padding makes input unaligned
+    VecT tmp;
+    VAL_T* lanes = reinterpret_cast<VAL_T*>(&tmp);
+
+    #pragma unroll
+    for (int w = 0; w < W; ++w) {
+        lanes[w] = getElem<VAL_T, CHANNELS_LAST>(
+            vin, i, j, k, padSize + l, padSize + m + w);
+    }
+    *dstVec = tmp;
+  } else {
+    // src and dst are both aligned
+    VecT srcVec = *reinterpret_cast<const VecT*>(
+      &getElem<VAL_T,CHANNELS_LAST>(vin,i,j,k, padSize+l, padSize+m));
+    *dstVec = srcVec;
+  }
+}
+
+template<typename VAL_T, bool CHANNELS_LAST>
+__global__ void HEALPixPadBck_bulk_k(const int padSize,
+				     const int dimI,
+				     const int dimJ,
+				     const int dimK,
+				     const int dimL,
+				     const int dimM,
+				     const torch::PackedTensorAccessor32<VAL_T, 5, torch::RestrictPtrTraits> vin,
+             torch::PackedTensorAccessor32<VAL_T, 5, torch::RestrictPtrTraits> vout) {
+
+  const long long tid = ((long long)blockIdx.x)*blockDim.x + threadIdx.x;
+
+  if (tid >= ((long long)dimI)*dimJ*dimK*dimL*dimM) {
+    return;
+  }
+
+
+  // compute individual indices
+  int i,j,k,l,m;
+  if constexpr(CHANNELS_LAST) {
+    k = (tid % dimK);
+    m = (tid / dimK) % dimM;
+    l = (tid / (dimK * dimM)) % dimL;
+    j = (tid / (dimK * dimM * dimL)) % dimJ;
+    i =  tid / (dimK * dimM * dimL * dimJ);
+  } else {
+    m = (tid % dimM);
+    l = (tid / dimM) % dimL;
+    k = (tid / (dimM * dimL)) % dimK;
+    j = (tid / (dimM * dimL * dimK)) % dimJ;
+    i =  tid / (dimM * dimL * dimK * dimJ);
+  }
+
+  getElemMutable<VAL_T, CHANNELS_LAST>(vout, i, j, k, l, m) = getElem<VAL_T, CHANNELS_LAST>(vin, i, j, k, padSize+l, padSize+m);
 
   return;
 }
 
-// faces functions
-
-template<typename VAL_T>
-__device__ VAL_T getTopFaceElem_d(const int k,
-				  const int m,
-				  const int dimL,
-				  const int dimM,
-				  const VAL_T *__restrict__ facePtr) {
-
-  return facePtr[k*dimL*dimM + m];
-}
-
-template<typename VAL_T>
-__device__ VAL_T getBottomFaceElem_d(const int k,
-				     const int m,
-				     const int dimL,
-				     const int dimM,
-				     const VAL_T *__restrict__ facePtr) {
-
-  return facePtr[k*dimL*dimM + (dimL-1)*dimM + m];
-}
-
-template<typename VAL_T>
-__device__ VAL_T getLeftFaceElem_d(const int k,
-				   const int l,
-				   const int dimL,
-				   const int dimM,
-				   const VAL_T *__restrict__ facePtr) {
-
-  return facePtr[k*dimL*dimM + l*dimM];
-}
-
-template<typename VAL_T>
-__device__ VAL_T getRightFaceElem_d(const int k,
-				    const int l,
-				    const int dimL,
-				    const int dimM,
-				    const VAL_T *__restrict__ facePtr) {
-
-  return facePtr[k*dimL*dimM + l*dimM + dimM-1];
-}
-
-template<typename VAL_T>
+template<typename VAL_T, bool CHANNELS_LAST>
 __device__ VAL_T getT_d(const int padSize,
 			const int k,
 			const int p,
@@ -130,32 +152,32 @@ __device__ VAL_T getT_d(const int padSize,
 			const int dimL,
 			const int dimM,
 			const int faceId,
-			const int faceLen,
-			const VAL_T *__restrict__ sphrPtr) {
+			const int sphrId,
+			const torch::PackedTensorAccessor32<VAL_T, 5, torch::RestrictPtrTraits> sphr) {
 
   VAL_T ret = VAL_T(0);
 
   switch(faceId) {
     // north faces
-  case  0: ret = getLeftFaceElem_d(k, m, dimL, dimM, sphrPtr + 1*faceLen + padSize*dimM + p); break;
-  case  1: ret = getLeftFaceElem_d(k, m, dimL, dimM, sphrPtr + 2*faceLen + padSize*dimM + p); break;
-  case  2: ret = getLeftFaceElem_d(k, m, dimL, dimM, sphrPtr + 3*faceLen + padSize*dimM + p); break;
-  case  3: ret = getLeftFaceElem_d(k, m, dimL, dimM, sphrPtr + 0*faceLen + padSize*dimM + p); break;
+  case  0: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 1, k, padSize+m, p); break;
+  case  1: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 2, k, padSize+m, p); break;
+  case  2: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 3, k, padSize+m, p); break;
+  case  3: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 0, k, padSize+m, p); break;
     // center faces
-  case  4: ret = getBottomFaceElem_d(k, m, dimL, dimM, sphrPtr + 0*faceLen + padSize - p*dimM); break;
-  case  5: ret = getBottomFaceElem_d(k, m, dimL, dimM, sphrPtr + 1*faceLen + padSize - p*dimM); break;
-  case  6: ret = getBottomFaceElem_d(k, m, dimL, dimM, sphrPtr + 2*faceLen + padSize - p*dimM); break;
-  case  7: ret = getBottomFaceElem_d(k, m, dimL, dimM, sphrPtr + 3*faceLen + padSize - p*dimM); break;
+  case  4: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 0, k, dimL-1-p, padSize+m); break;
+  case  5: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 1, k, dimL-1-p, padSize+m); break;
+  case  6: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 2, k, dimL-1-p, padSize+m); break;
+  case  7: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 3, k, dimL-1-p, padSize+m); break;
     // south faces
-  case  8: ret = getBottomFaceElem_d(k, m, dimL, dimM, sphrPtr + 5*faceLen + padSize - p*dimM); break;
-  case  9: ret = getBottomFaceElem_d(k, m, dimL, dimM, sphrPtr + 6*faceLen + padSize - p*dimM); break;
-  case 10: ret = getBottomFaceElem_d(k, m, dimL, dimM, sphrPtr + 7*faceLen + padSize - p*dimM); break;
-  case 11: ret = getBottomFaceElem_d(k, m, dimL, dimM, sphrPtr + 4*faceLen + padSize - p*dimM); break;
+  case  8: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 5, k, dimL-1-p, padSize+m); break;
+  case  9: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 6, k, dimL-1-p, padSize+m); break;
+  case 10: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 7, k, dimL-1-p, padSize+m); break;
+  case 11: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 4, k, dimL-1-p, padSize+m); break;
   }
   return ret;
 }
 
-template<typename VAL_T>
+template<typename VAL_T, bool CHANNELS_LAST>
 __device__ VAL_T getB_d(const int padSize,
 			const int k,
 			const int p,
@@ -163,32 +185,34 @@ __device__ VAL_T getB_d(const int padSize,
 			const int dimL,
 			const int dimM,
 			const int faceId,
-			const int faceLen,
-			const VAL_T *__restrict__ sphrPtr) {
+			const int sphrId,
+			const torch::PackedTensorAccessor32<VAL_T, 5, torch::RestrictPtrTraits> sphr) {
 
   VAL_T ret = VAL_T(0);
 
   switch(faceId) {
     // north faces
-  case  0: ret = getTopFaceElem_d(k, m, dimL, dimM, sphrPtr + 4*faceLen + padSize + p*dimM); break;
-  case  1: ret = getTopFaceElem_d(k, m, dimL, dimM, sphrPtr + 5*faceLen + padSize + p*dimM); break;
-  case  2: ret = getTopFaceElem_d(k, m, dimL, dimM, sphrPtr + 6*faceLen + padSize + p*dimM); break;
-  case  3: ret = getTopFaceElem_d(k, m, dimL, dimM, sphrPtr + 7*faceLen + padSize + p*dimM); break;
+    //facePtr[k*dimL*dimM + m]
+  case  0: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  4, k, p, padSize+m); break;
+  case  1: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  5, k, p, padSize+m); break;
+  case  2: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  6, k, p, padSize+m); break;
+  case  3: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  7, k, p, padSize+m); break;
     // center faces
-  case  4: ret = getTopFaceElem_d(k, m, dimL, dimM, sphrPtr + 11*faceLen + padSize + p*dimM); break;
-  case  5: ret = getTopFaceElem_d(k, m, dimL, dimM, sphrPtr +  8*faceLen + padSize + p*dimM); break;
-  case  6: ret = getTopFaceElem_d(k, m, dimL, dimM, sphrPtr +  9*faceLen + padSize + p*dimM); break;
-  case  7: ret = getTopFaceElem_d(k, m, dimL, dimM, sphrPtr + 10*faceLen + padSize + p*dimM); break;
+  case  4: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 11, k, p, padSize+m); break;
+  case  5: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  8, k, p, padSize+m); break;
+  case  6: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  9, k, p, padSize+m); break;
+  case  7: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 10, k, p, padSize+m); break;
     // south faces
-  case  8: ret = getRightFaceElem_d(k, m, dimL, dimM, sphrPtr + 11*faceLen + padSize*dimM - p); break;
-  case  9: ret = getRightFaceElem_d(k, m, dimL, dimM, sphrPtr +  8*faceLen + padSize*dimM - p); break;
-  case 10: ret = getRightFaceElem_d(k, m, dimL, dimM, sphrPtr +  9*faceLen + padSize*dimM - p); break;
-  case 11: ret = getRightFaceElem_d(k, m, dimL, dimM, sphrPtr + 10*faceLen + padSize*dimM - p); break;
+    // facePtr[k*dimL*dimM + l*dimM + dimM-1];
+  case  8: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 11, k, padSize+m, dimM-1-p); break;
+  case  9: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  8, k, padSize+m, dimM-1-p); break;
+  case 10: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  9, k, padSize+m, dimM-1-p); break;
+  case 11: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 10, k, padSize+m, dimM-1-p); break;
   }
   return ret;
 }
 
-template<typename VAL_T>
+template<typename VAL_T, bool CHANNELS_LAST>
 __device__ VAL_T getL_d(const int padSize,
 			const int k,
 			const int p,
@@ -196,32 +220,32 @@ __device__ VAL_T getL_d(const int padSize,
 			const int dimL,
 			const int dimM,
 			const int faceId,
-			const int faceLen,
-			const VAL_T *__restrict__ sphrPtr) {
+			const int sphrId,
+      const torch::PackedTensorAccessor32<VAL_T, 5, torch::RestrictPtrTraits> sphr) {
 
   VAL_T ret = VAL_T(0);
 
   switch(faceId) {
     // north faces
-  case  0: ret = getTopFaceElem_d(k, m, dimL, dimM, sphrPtr + 3*faceLen + padSize + p*dimM); break;
-  case  1: ret = getTopFaceElem_d(k, m, dimL, dimM, sphrPtr + 0*faceLen + padSize + p*dimM); break;
-  case  2: ret = getTopFaceElem_d(k, m, dimL, dimM, sphrPtr + 1*faceLen + padSize + p*dimM); break;
-  case  3: ret = getTopFaceElem_d(k, m, dimL, dimM, sphrPtr + 2*faceLen + padSize + p*dimM); break;
+  case  0: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  3, k, p, padSize+m); break;
+  case  1: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  0, k, p, padSize+m); break;
+  case  2: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  1, k, p, padSize+m); break;
+  case  3: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  2, k, p, padSize+m); break;
     // center faces
-  case  4: ret = getRightFaceElem_d(k, m, dimL, dimM, sphrPtr + 3*faceLen + padSize*dimM - p); break;
-  case  5: ret = getRightFaceElem_d(k, m, dimL, dimM, sphrPtr + 0*faceLen + padSize*dimM - p); break;
-  case  6: ret = getRightFaceElem_d(k, m, dimL, dimM, sphrPtr + 1*faceLen + padSize*dimM - p); break;
-  case  7: ret = getRightFaceElem_d(k, m, dimL, dimM, sphrPtr + 2*faceLen + padSize*dimM - p); break;
+  case  4: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  3, k, padSize+m, dimM-1-p); break;
+  case  5: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  0, k, padSize+m, dimM-1-p); break;
+  case  6: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  1, k, padSize+m, dimM-1-p); break;
+  case  7: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  2, k, padSize+m, dimM-1-p); break;
     // south faces
-  case  8: ret = getRightFaceElem_d(k, m, dimL, dimM, sphrPtr + 4*faceLen + padSize*dimM - p); break;
-  case  9: ret = getRightFaceElem_d(k, m, dimL, dimM, sphrPtr + 5*faceLen + padSize*dimM - p); break;
-  case 10: ret = getRightFaceElem_d(k, m, dimL, dimM, sphrPtr + 6*faceLen + padSize*dimM - p); break;
-  case 11: ret = getRightFaceElem_d(k, m, dimL, dimM, sphrPtr + 7*faceLen + padSize*dimM - p); break;
+  case  8: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  4, k, padSize+m, dimM-1-p); break;
+  case  9: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  5, k, padSize+m, dimM-1-p); break;
+  case 10: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  6, k, padSize+m, dimM-1-p); break;
+  case 11: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  7, k, padSize+m, dimM-1-p); break;
   }
   return ret;
 }
 
-template<typename VAL_T>
+template<typename VAL_T, bool CHANNELS_LAST>
 __device__ VAL_T getR_d(const int padSize,
 			const int k,
 			const int p,
@@ -229,40 +253,40 @@ __device__ VAL_T getR_d(const int padSize,
 			const int dimL,
 			const int dimM,
 			const int faceId,
-			const int faceLen,
-			const VAL_T *__restrict__ sphrPtr) {
+			const int sphrId,
+      const torch::PackedTensorAccessor32<VAL_T, 5, torch::RestrictPtrTraits> sphr) {
 
   VAL_T ret = VAL_T(0);
 
   switch(faceId) {
     // north faces
-  case  0: ret = getLeftFaceElem_d(k, m, dimL, dimM, sphrPtr + 5*faceLen + padSize*dimM + p); break;
-  case  1: ret = getLeftFaceElem_d(k, m, dimL, dimM, sphrPtr + 6*faceLen + padSize*dimM + p); break;
-  case  2: ret = getLeftFaceElem_d(k, m, dimL, dimM, sphrPtr + 7*faceLen + padSize*dimM + p); break;
-  case  3: ret = getLeftFaceElem_d(k, m, dimL, dimM, sphrPtr + 4*faceLen + padSize*dimM + p); break;
+  case  0: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  5, k, padSize+m, p); break;
+  case  1: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  6, k, padSize+m, p); break;
+  case  2: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  7, k, padSize+m, p); break;
+  case  3: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  4, k, padSize+m, p); break;
     // center faces
-  case  4: ret = getLeftFaceElem_d(k, m, dimL, dimM, sphrPtr +  8*faceLen + padSize*dimM + p); break;
-  case  5: ret = getLeftFaceElem_d(k, m, dimL, dimM, sphrPtr +  9*faceLen + padSize*dimM + p); break;
-  case  6: ret = getLeftFaceElem_d(k, m, dimL, dimM, sphrPtr + 10*faceLen + padSize*dimM + p); break;
-  case  7: ret = getLeftFaceElem_d(k, m, dimL, dimM, sphrPtr + 11*faceLen + padSize*dimM + p); break;
+  case  4: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  8, k, padSize+m, p); break;
+  case  5: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  9, k, padSize+m, p); break;
+  case  6: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 10, k, padSize+m, p); break;
+  case  7: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 11, k, padSize+m, p); break;
     // south faces
-  case  8: ret = getBottomFaceElem_d(k, m, dimL, dimM, sphrPtr +  9*faceLen + padSize - p*dimM); break;
-  case  9: ret = getBottomFaceElem_d(k, m, dimL, dimM, sphrPtr + 10*faceLen + padSize - p*dimM); break;
-  case 10: ret = getBottomFaceElem_d(k, m, dimL, dimM, sphrPtr + 11*faceLen + padSize - p*dimM); break;
-  case 11: ret = getBottomFaceElem_d(k, m, dimL, dimM, sphrPtr +  8*faceLen + padSize - p*dimM); break;
+  case  8: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  9, k, dimL-1-p, padSize+m); break;
+  case  9: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 10, k, dimL-1-p, padSize+m); break;
+  case 10: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 11, k, dimL-1-p, padSize+m); break;
+  case 11: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  8, k, dimL-1-p, padSize+m); break;
   }
   return ret;
 }
 
-template<typename VAL_T>
+template<typename VAL_T, bool CHANNELS_LAST>
 __global__ void HEALPixPadBck_haloTB_k(const int padSize,
 				       const int dimI,
 				       const int dimJ, // = 12
 				       const int dimK,
 				       const int dimL,
 				       const int dimM,
-				       const VAL_T *__restrict__ vin,
-				       VAL_T *__restrict__ vout) {
+				       const torch::PackedTensorAccessor32<VAL_T, 5, torch::RestrictPtrTraits> vin,
+				       torch::PackedTensorAccessor32<VAL_T, 5, torch::RestrictPtrTraits> vout) {
 
   const long long tid = ((long long)blockIdx.x)*blockDim.x + threadIdx.x;
 
@@ -276,33 +300,36 @@ __global__ void HEALPixPadBck_haloTB_k(const int padSize,
   const int dimLI = dimL + 2*padSize;
   const int dimMI = dimM + 2*padSize;
 
-  const long long faceLenI = ((long long)dimK)*dimLI*dimMI;
-  const long long faceLenO = ((long long)dimK)*dimL *dimM;
-
-  const VAL_T *__restrict__ sphrPtrI = vin  +  sphrId*dimJ          *faceLenI;
-  VAL_T *__restrict__ facePtrO = vout + (sphrId*dimJ + faceId)*faceLenO;
-
-  const int k = (tid / (padSize*dimM)) % dimK;
-  const int p = (tid /          dimM)  % padSize;
-  const int m =  tid                   % dimM;
+  int k, p, m;
+  if constexpr (CHANNELS_LAST) {
+    k =  tid % dimK;
+    p = (tid / dimK)            % padSize;
+    m = (tid / (dimK * padSize)) % dimM;
+  } else {
+    m =  tid % dimM;
+    p = (tid / dimM)            % padSize;
+    k = (tid / (dimM * padSize)) % dimK;
+  }
 
   // copy top    face
   // copy bottom face
-  facePtrO[k*dimL*dimM +    (padSize-1)*dimM + m - p*dimM] += getT_d(padSize, k, p, m, dimLI, dimMI, faceId, faceLenI, sphrPtrI);
-  facePtrO[k*dimL*dimM + (dimL-padSize)*dimM + m + p*dimM] += getB_d(padSize, k, p, m, dimLI, dimMI, faceId, faceLenI, sphrPtrI);
+  getElemMutable<VAL_T, CHANNELS_LAST>(vout, sphrId, faceId, k,   padSize-1-p, m) \
+    += getT_d<VAL_T, CHANNELS_LAST>(padSize, k, p, m, dimLI, dimMI, faceId, sphrId, vin);
+  getElemMutable<VAL_T, CHANNELS_LAST>(vout, sphrId, faceId, k, dimL-padSize+p, m) \
+    += getB_d<VAL_T, CHANNELS_LAST>(padSize, k, p, m, dimLI, dimMI, faceId, sphrId, vin);
 
   return;
 }
 
-template<typename VAL_T>
+template<typename VAL_T, bool CHANNELS_LAST>
 __global__ void HEALPixPadBck_haloLR_k(const int padSize,
 				       const int dimI,
 				       const int dimJ, // = 12
 				       const int dimK,
 				       const int dimL,
 				       const int dimM,
-				       const VAL_T *__restrict__ vin,
-				       VAL_T *__restrict__ vout) {
+				       const torch::PackedTensorAccessor32<VAL_T, 5, torch::RestrictPtrTraits> vin,
+               torch::PackedTensorAccessor32<VAL_T, 5, torch::RestrictPtrTraits> vout) {
 
   const long long tid = ((long long)blockIdx.x)*blockDim.x + threadIdx.x;
 
@@ -316,63 +343,28 @@ __global__ void HEALPixPadBck_haloLR_k(const int padSize,
   const int dimLI = dimL + 2*padSize;
   const int dimMI = dimM + 2*padSize;
 
-  const long long faceLenI = ((long long)dimK)*dimLI*dimMI;
-  const long long faceLenO = ((long long)dimK)*dimL *dimM;
-
-  const VAL_T *__restrict__ sphrPtrI = vin  +  sphrId*dimJ          *faceLenI;
-  VAL_T *__restrict__ facePtrO = vout + (sphrId*dimJ + faceId)*faceLenO;
-
-  const int k = (tid / (padSize*dimM)) % dimK;
-  const int p = (tid /          dimM)  % padSize;
-  const int m =  tid                   % dimM;
+  int k, p, m;
+  if constexpr (CHANNELS_LAST) {
+    k =  tid % dimK;
+    p = (tid / dimK)            % padSize;
+    m = (tid / (dimK * padSize)) % dimM;
+  } else {
+    m =  tid % dimM;
+    p = (tid / dimM)            % padSize;
+    k = (tid / (dimM * padSize)) % dimK;
+  }
 
   // copy left   face
   // copy right  face
-  facePtrO[k*dimL*dimM + m*dimM +    padSize-1 - p] += getL_d(padSize, k, p, m, dimLI, dimMI, faceId, faceLenI, sphrPtrI);
-  facePtrO[k*dimL*dimM + m*dimM + dimM-padSize + p] += getR_d(padSize, k, p, m, dimLI, dimMI, faceId, faceLenI, sphrPtrI);
+  getElemMutable<VAL_T, CHANNELS_LAST>(vout, sphrId, faceId, k, m, padSize-1-p) \
+    += getL_d<VAL_T, CHANNELS_LAST>(padSize, k, p, m, dimLI, dimMI, faceId, sphrId, vin);
+  getElemMutable<VAL_T, CHANNELS_LAST>(vout, sphrId, faceId, k, m, dimM-padSize+p) \
+    += getR_d<VAL_T, CHANNELS_LAST>(padSize, k, p, m, dimLI, dimMI, faceId, sphrId, vin);
 
   return;
 }
 
-// corners functions
-
-template<typename VAL_T>
-__device__ VAL_T getTopLeftCornerElem_d(const int k,
-					const int dimL,
-					const int dimM,
-					const VAL_T *__restrict__ facePtr) {
-
-  return facePtr[k*dimL*dimM];
-}
-
-template<typename VAL_T>
-__device__ VAL_T getTopRightCornerElem_d(const int k,
-					 const int dimL,
-					 const int dimM,
-					 const VAL_T *__restrict__ facePtr) {
-
-  return facePtr[k*dimL*dimM + dimM-1];
-}
-
-template<typename VAL_T>
-__device__ VAL_T getBottomLeftCornerElem_d(const int k,
-					   const int dimL,
-					   const int dimM,
-					   const VAL_T *__restrict__ facePtr) {
-
-  return facePtr[k*dimL*dimM + (dimL-1)*dimM];
-}
-
-template<typename VAL_T>
-__device__ VAL_T getBottomRightCornerElem_d(const int k,
-					    const int dimL,
-					    const int dimM,
-					    const VAL_T *__restrict__ facePtr) {
-
-  return facePtr[k*dimL*dimM + dimL*dimM-1];
-}
-
-template<typename VAL_T>
+template<typename VAL_T, bool CHANNELS_LAST>
 __device__ VAL_T getTL_d(const int padSize,
 			 const int p,
 			 const int q,
@@ -380,39 +372,36 @@ __device__ VAL_T getTL_d(const int padSize,
 			 const int dimL,
 			 const int dimM,
 			 const int faceId,
-			 const int faceLen,
-			 const VAL_T *__restrict__ sphrPtr) {
+			 const int sphrId,
+			 const torch::PackedTensorAccessor32<VAL_T, 5, torch::RestrictPtrTraits> sphr) {
 
   VAL_T ret = VAL_T(0);
 
   const int pinv = padSize-1 - p;
   const int qinv = padSize-1 - q;
 
-  // offset from neighbor's corner
-  // for non equatorial faces
-  const int padOff = pinv*dimM + qinv;
-
   switch(faceId) {
     // north faces
-  case  0: ret = getTopLeftCornerElem_d(k, dimL, dimM, sphrPtr + 2*faceLen + padOff); break;
-  case  1: ret = getTopLeftCornerElem_d(k, dimL, dimM, sphrPtr + 3*faceLen + padOff); break;
-  case  2: ret = getTopLeftCornerElem_d(k, dimL, dimM, sphrPtr + 0*faceLen + padOff); break;
-  case  3: ret = getTopLeftCornerElem_d(k, dimL, dimM, sphrPtr + 1*faceLen + padOff); break;
+  case  0: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 2, k, pinv, qinv); break;
+  case  1: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 3, k, pinv, qinv); break;
+  case  2: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 0, k, pinv, qinv); break;
+  case  3: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 1, k, pinv, qinv); break;
     // center faces
   case  4:
   case  5:
   case  6:
   case  7: break;
     // south faces
-  case  8: ret = getBottomRightCornerElem_d(k, dimL, dimM, sphrPtr + 0*faceLen - padOff); break;
-  case  9: ret = getBottomRightCornerElem_d(k, dimL, dimM, sphrPtr + 1*faceLen - padOff); break;
-  case 10: ret = getBottomRightCornerElem_d(k, dimL, dimM, sphrPtr + 2*faceLen - padOff); break;
-  case 11: ret = getBottomRightCornerElem_d(k, dimL, dimM, sphrPtr + 3*faceLen - padOff); break;
+    // facePtr[k*dimL*dimM + dimL*dimM-1];
+  case  8: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 0, k, dimL-pinv, -qinv-1); break;
+  case  9: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 1, k, dimL-pinv, -qinv-1); break;
+  case 10: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 2, k, dimL-pinv, -qinv-1); break;
+  case 11: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 3, k, dimL-pinv, -qinv-1); break;
   }
   return ret;
 }
 
-template<typename VAL_T>
+template<typename VAL_T, bool CHANNELS_LAST>
 __device__ VAL_T getTR_d(const int padSize,
 			 const int p,
 			 const int q,
@@ -420,94 +409,77 @@ __device__ VAL_T getTR_d(const int padSize,
 			 const int dimL,
 			 const int dimM,
 			 const int faceId,
-			 const int faceLen,
-			 const VAL_T *__restrict__ sphrPtr) {
+			 const int sphrId,
+       const torch::PackedTensorAccessor32<VAL_T, 5, torch::RestrictPtrTraits> sphr) {
 
   VAL_T ret = VAL_T(0);
 
   const int pinv = padSize-1 - p;
 
-  // offset from neighbor's corner
-  // for non equatorial faces
-  const int padOff = -pinv*dimM + q;
-
   switch(faceId) {
     // north faces
-  case  0: ret = getBottomLeftCornerElem_d(k, dimL, dimM, sphrPtr + 1*faceLen + padOff); break;
-  case  1: ret = getBottomLeftCornerElem_d(k, dimL, dimM, sphrPtr + 2*faceLen + padOff); break;
-  case  2: ret = getBottomLeftCornerElem_d(k, dimL, dimM, sphrPtr + 3*faceLen + padOff); break;
-  case  3: ret = getBottomLeftCornerElem_d(k, dimL, dimM, sphrPtr + 0*faceLen + padOff); break;
+  case  0: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  1, k, dimL-1-pinv, q); break;
+  case  1: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  2, k, dimL-1-pinv, q); break;
+  case  2: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  3, k, dimL-1-pinv, q); break;
+  case  3: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  0, k, dimL-1-pinv, q); break;
     // center faces
-  case  4: ret = getBottomLeftCornerElem_d(k, dimL, dimM, sphrPtr + 5*faceLen + padOff); break;
-  case  5: ret = getBottomLeftCornerElem_d(k, dimL, dimM, sphrPtr + 6*faceLen + padOff); break;
-  case  6: ret = getBottomLeftCornerElem_d(k, dimL, dimM, sphrPtr + 7*faceLen + padOff); break;
-  case  7: ret = getBottomLeftCornerElem_d(k, dimL, dimM, sphrPtr + 4*faceLen + padOff); break;
+  case  4: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  5, k, dimL-1-pinv, q); break;
+  case  5: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  6, k, dimL-1-pinv, q); break;
+  case  6: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  7, k, dimL-1-pinv, q); break;
+  case  7: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  4, k, dimL-1-pinv, q); break;
     // south faces
-  case  8: ret = getBottomLeftCornerElem_d(k, dimL, dimM, sphrPtr +  9*faceLen + padOff); break;
-  case  9: ret = getBottomLeftCornerElem_d(k, dimL, dimM, sphrPtr + 10*faceLen + padOff); break;
-  case 10: ret = getBottomLeftCornerElem_d(k, dimL, dimM, sphrPtr + 11*faceLen + padOff); break;
-  case 11: ret = getBottomLeftCornerElem_d(k, dimL, dimM, sphrPtr +  8*faceLen + padOff); break;
+  case  8: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  9, k, dimL-1-pinv, q); break;
+  case  9: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 10, k, dimL-1-pinv, q); break;
+  case 10: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 11, k, dimL-1-pinv, q); break;
+  case 11: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  8, k, dimL-1-pinv, q); break;
   }
-
-  // offsets from neighbor' corners
-  // for north and south faces
-  const int topLeftPadOff  = (q+1 + p)*dimM + q;
-
-  // north faces get values in the top left tringle
-  // of their corner square from half the corner of
-  // other faces
 
   if (p+q < padSize-1) {
     switch(faceId) {
       // north faces
-    case  0: ret += getTopLeftCornerElem_d(k, dimL, dimM, sphrPtr + 5*faceLen + topLeftPadOff); break;
-    case  1: ret += getTopLeftCornerElem_d(k, dimL, dimM, sphrPtr + 6*faceLen + topLeftPadOff); break;
-    case  2: ret += getTopLeftCornerElem_d(k, dimL, dimM, sphrPtr + 7*faceLen + topLeftPadOff); break;
-    case  3: ret += getTopLeftCornerElem_d(k, dimL, dimM, sphrPtr + 4*faceLen + topLeftPadOff); break;
+    case  0: ret += getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  5, k, q+1+p, q); break;
+    case  1: ret += getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  6, k, q+1+p, q); break;
+    case  2: ret += getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  7, k, q+1+p, q); break;
+    case  3: ret += getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  4, k, q+1+p, q); break;
     }
   }
 
   if (p == 0) {
     switch(faceId) {
       // north faces
-    case  0: ret += getTopLeftCornerElem_d(k, dimL, dimM, sphrPtr + 5*faceLen + q*dimM + q) / VAL_T(2); break;
-    case  1: ret += getTopLeftCornerElem_d(k, dimL, dimM, sphrPtr + 6*faceLen + q*dimM + q) / VAL_T(2); break;
-    case  2: ret += getTopLeftCornerElem_d(k, dimL, dimM, sphrPtr + 7*faceLen + q*dimM + q) / VAL_T(2); break;
-    case  3: ret += getTopLeftCornerElem_d(k, dimL, dimM, sphrPtr + 4*faceLen + q*dimM + q) / VAL_T(2); break;
+    case  0: ret += getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  5, k, q, q) / VAL_T(2); break;
+    case  1: ret += getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  6, k, q, q) / VAL_T(2); break;
+    case  2: ret += getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  7, k, q, q) / VAL_T(2); break;
+    case  3: ret += getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  4, k, q, q) / VAL_T(2); break;
     }
   }
 
   const int qinv = padSize-1 - q;
-  const int bottomRightOff = -pinv*dimM - (pinv+1 + qinv);
-
-  // south faces get values in the bottom right tringle
-  // of their corner square from half the corner of
-  // other faces
-
   if (p+q > padSize-1) {
     switch(faceId) {
       // south faces
-    case  8: ret += getBottomRightCornerElem_d(k, dimL, dimM, sphrPtr +  5*faceLen + bottomRightOff); break;
-    case  9: ret += getBottomRightCornerElem_d(k, dimL, dimM, sphrPtr +  6*faceLen + bottomRightOff); break;
-    case 10: ret += getBottomRightCornerElem_d(k, dimL, dimM, sphrPtr +  7*faceLen + bottomRightOff); break;
-    case 11: ret += getBottomRightCornerElem_d(k, dimL, dimM, sphrPtr +  4*faceLen + bottomRightOff); break;
+      //facePtr[k*dimL*dimM + dimL*dimM-1];
+    case  8: ret += getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  5, k, dimL-pinv, -(pinv+1+qinv)-1); break;
+    case  9: ret += getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  6, k, dimL-pinv, -(pinv+1+qinv)-1); break;
+    case 10: ret += getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  7, k, dimL-pinv, -(pinv+1+qinv)-1); break;
+    case 11: ret += getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  4, k, dimL-pinv, -(pinv+1+qinv)-1); break;
     }
   }
 
   if (q == padSize-1) {
     switch(faceId) {
       // south faces
-    case  8: ret += getBottomRightCornerElem_d(k, dimL, dimM, sphrPtr +  5*faceLen - pinv*dimM - pinv) / VAL_T(2); break;
-    case  9: ret += getBottomRightCornerElem_d(k, dimL, dimM, sphrPtr +  6*faceLen - pinv*dimM - pinv) / VAL_T(2); break;
-    case 10: ret += getBottomRightCornerElem_d(k, dimL, dimM, sphrPtr +  7*faceLen - pinv*dimM - pinv) / VAL_T(2); break;
-    case 11: ret += getBottomRightCornerElem_d(k, dimL, dimM, sphrPtr +  4*faceLen - pinv*dimM - pinv) / VAL_T(2); break;
+    case  8: ret += getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  5, k, dimL-pinv, -pinv-1) / VAL_T(2); break;
+    case  9: ret += getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  6, k, dimL-pinv, -pinv-1) / VAL_T(2); break;
+    case 10: ret += getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  7, k, dimL-pinv, -pinv-1) / VAL_T(2); break;
+    case 11: ret += getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  4, k, dimL-pinv, -pinv-1) / VAL_T(2); break;
     }
   }
 
   return ret;
 }
 
-template<typename VAL_T>
+template<typename VAL_T, bool CHANNELS_LAST>
 __device__ VAL_T getBL_d(const int padSize,
 			 const int p,
 			 const int q,
@@ -515,89 +487,75 @@ __device__ VAL_T getBL_d(const int padSize,
 			 const int dimL,
 			 const int dimM,
 			 const int faceId,
-			 const int faceLen,
-			 const VAL_T *__restrict__ sphrPtr) {
+			 const int sphrId,
+       const torch::PackedTensorAccessor32<VAL_T, 5, torch::RestrictPtrTraits> sphr) {
 
   VAL_T ret = VAL_T(0);
 
   const int qinv = padSize-1 - q;
 
-  // offset from neighbor's corner
-  // for non equatorial faces
-  const int padOff = p*dimM - qinv;
-
   switch(faceId) {
     // north faces
-  case  0: ret = getTopRightCornerElem_d(k, dimL, dimM, sphrPtr + 3*faceLen + padOff); break;
-  case  1: ret = getTopRightCornerElem_d(k, dimL, dimM, sphrPtr + 0*faceLen + padOff); break;
-  case  2: ret = getTopRightCornerElem_d(k, dimL, dimM, sphrPtr + 1*faceLen + padOff); break;
-  case  3: ret = getTopRightCornerElem_d(k, dimL, dimM, sphrPtr + 2*faceLen + padOff); break;
+  case  0: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  3, k, p, dimM-1-qinv); break;
+  case  1: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  0, k, p, dimM-1-qinv); break;
+  case  2: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  1, k, p, dimM-1-qinv); break;
+  case  3: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  2, k, p, dimM-1-qinv); break;
     // center faces
-  case  4: ret = getTopRightCornerElem_d(k, dimL, dimM, sphrPtr + 7*faceLen + padOff); break;
-  case  5: ret = getTopRightCornerElem_d(k, dimL, dimM, sphrPtr + 4*faceLen + padOff); break;
-  case  6: ret = getTopRightCornerElem_d(k, dimL, dimM, sphrPtr + 5*faceLen + padOff); break;
-  case  7: ret = getTopRightCornerElem_d(k, dimL, dimM, sphrPtr + 6*faceLen + padOff); break;
+  case  4: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  7, k, p, dimM-1-qinv); break;
+  case  5: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  4, k, p, dimM-1-qinv); break;
+  case  6: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  5, k, p, dimM-1-qinv); break;
+  case  7: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  6, k, p, dimM-1-qinv); break;
     // south faces
-  case  8: ret = getTopRightCornerElem_d(k, dimL, dimM, sphrPtr + 11*faceLen + padOff); break;
-  case  9: ret = getTopRightCornerElem_d(k, dimL, dimM, sphrPtr +  8*faceLen + padOff); break;
-  case 10: ret = getTopRightCornerElem_d(k, dimL, dimM, sphrPtr +  9*faceLen + padOff); break;
-  case 11: ret = getTopRightCornerElem_d(k, dimL, dimM, sphrPtr + 10*faceLen + padOff); break;
+  case  8: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 11, k, p, dimM-1-qinv); break;
+  case  9: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  8, k, p, dimM-1-qinv); break;
+  case 10: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  9, k, p, dimM-1-qinv); break;
+  case 11: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 10, k, p, dimM-1-qinv); break;
   }
-
-  // offsets from neighbor' corners
-  // for north and south faces
-  const int bottomLeftPadOff  = p*dimM + p+1+q; //(q+1 + p)*dimM + q;
 
   if (p+q < padSize-1) {
     switch(faceId) {
       // north faces
-    case  0: ret += getTopLeftCornerElem_d(k, dimL, dimM, sphrPtr + 4*faceLen + bottomLeftPadOff); break;
-    case  1: ret += getTopLeftCornerElem_d(k, dimL, dimM, sphrPtr + 5*faceLen + bottomLeftPadOff); break;
-    case  2: ret += getTopLeftCornerElem_d(k, dimL, dimM, sphrPtr + 6*faceLen + bottomLeftPadOff); break;
-    case  3: ret += getTopLeftCornerElem_d(k, dimL, dimM, sphrPtr + 7*faceLen + bottomLeftPadOff); break;
+    case  0: ret += getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  4, k, p, p+q+1); break;
+    case  1: ret += getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  5, k, p, p+q+1); break;
+    case  2: ret += getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  6, k, p, p+q+1); break;
+    case  3: ret += getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  7, k, p, p+q+1); break;
     }
   }
 
   if (q == 0) {
     switch(faceId) {
       // north faces
-    case  0: ret += getTopLeftCornerElem_d(k, dimL, dimM, sphrPtr + 4*faceLen + p*dimM + p) / VAL_T(2); break;
-    case  1: ret += getTopLeftCornerElem_d(k, dimL, dimM, sphrPtr + 5*faceLen + p*dimM + p) / VAL_T(2); break;
-    case  2: ret += getTopLeftCornerElem_d(k, dimL, dimM, sphrPtr + 6*faceLen + p*dimM + p) / VAL_T(2); break;
-    case  3: ret += getTopLeftCornerElem_d(k, dimL, dimM, sphrPtr + 7*faceLen + p*dimM + p) / VAL_T(2); break;
+    case  0: ret += getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  4, k, p, p) / VAL_T(2); break;
+    case  1: ret += getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  5, k, p, p) / VAL_T(2); break;
+    case  2: ret += getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  6, k, p, p) / VAL_T(2); break;
+    case  3: ret += getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  7, k, p, p) / VAL_T(2); break;
     }
   }
 
-  //const int pinv = padSize-1 - p;
-  const int bottomRightOff = (2*padSize - p - q -1)*dimM + qinv; //-(pinv + q-1)*dimM + q;
-
-  // south faces get values in the bottom right tringle
-  // of their corner square from half the corner of
-  // other faces
   if (p+q > padSize-1) {
     switch(faceId) {
       // south faces
-    case  8: ret += getBottomRightCornerElem_d(k, dimL, dimM, sphrPtr +  4*faceLen - bottomRightOff); break;
-    case  9: ret += getBottomRightCornerElem_d(k, dimL, dimM, sphrPtr +  5*faceLen - bottomRightOff); break;
-    case 10: ret += getBottomRightCornerElem_d(k, dimL, dimM, sphrPtr +  6*faceLen - bottomRightOff); break;
-    case 11: ret += getBottomRightCornerElem_d(k, dimL, dimM, sphrPtr +  7*faceLen - bottomRightOff); break;
+    case  8: ret += getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  4, k, dimL-2*padSize+p+q+1, -qinv-1); break;
+    case  9: ret += getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  5, k, dimL-2*padSize+p+q+1, -qinv-1); break;
+    case 10: ret += getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  6, k, dimL-2*padSize+p+q+1, -qinv-1); break;
+    case 11: ret += getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  7, k, dimL-2*padSize+p+q+1, -qinv-1); break;
     }
   }
 
   if (p == padSize-1) {
     switch(faceId) {
       // south faces
-    case  8: ret += getBottomRightCornerElem_d(k, dimL, dimM, sphrPtr +  4*faceLen - qinv*dimM - qinv) / VAL_T(2); break;
-    case  9: ret += getBottomRightCornerElem_d(k, dimL, dimM, sphrPtr +  5*faceLen - qinv*dimM - qinv) / VAL_T(2); break;
-    case 10: ret += getBottomRightCornerElem_d(k, dimL, dimM, sphrPtr +  6*faceLen - qinv*dimM - qinv) / VAL_T(2); break;
-    case 11: ret += getBottomRightCornerElem_d(k, dimL, dimM, sphrPtr +  7*faceLen - qinv*dimM - qinv) / VAL_T(2); break;
+    case  8: ret += getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  4, k, dimL-qinv, -qinv-1) / VAL_T(2); break;
+    case  9: ret += getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  5, k, dimL-qinv, -qinv-1) / VAL_T(2); break;
+    case 10: ret += getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  6, k, dimL-qinv, -qinv-1) / VAL_T(2); break;
+    case 11: ret += getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  7, k, dimL-qinv, -qinv-1) / VAL_T(2); break;
     }
   }
 
   return ret;
 }
 
-template<typename VAL_T>
+template<typename VAL_T, bool CHANNELS_LAST>
 __device__ VAL_T getBR_d(const int padSize,
 			 const int p,
 			 const int q,
@@ -605,44 +563,41 @@ __device__ VAL_T getBR_d(const int padSize,
 			 const int dimL,
 			 const int dimM,
 			 const int faceId,
-			 const int faceLen,
-			 const VAL_T *__restrict__ sphrPtr) {
+			 const int sphrId,
+       const torch::PackedTensorAccessor32<VAL_T, 5, torch::RestrictPtrTraits> sphr) {
 
   VAL_T ret = VAL_T(0);
 
-  // offset from neighbor's corner
-  // for non equatorial faces
-  const int padOff = p*dimM + q;
-
   switch(faceId) {
     // north faces
-  case  0: ret = getTopLeftCornerElem_d(k, dimL, dimM, sphrPtr +  8*faceLen + padOff); break;
-  case  1: ret = getTopLeftCornerElem_d(k, dimL, dimM, sphrPtr +  9*faceLen + padOff); break;
-  case  2: ret = getTopLeftCornerElem_d(k, dimL, dimM, sphrPtr + 10*faceLen + padOff); break;
-  case  3: ret = getTopLeftCornerElem_d(k, dimL, dimM, sphrPtr + 11*faceLen + padOff); break;
+  case  0: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  8, k, p, q); break;
+  case  1: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  9, k, p, q); break;
+  case  2: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 10, k, p, q); break;
+  case  3: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 11, k, p, q); break;
     // center faces
   case  4:
   case  5:
   case  6:
   case  7: break;
     // south faces
-  case  8: ret = getBottomRightCornerElem_d(k, dimL, dimM, sphrPtr + 10*faceLen - padOff); break;
-  case  9: ret = getBottomRightCornerElem_d(k, dimL, dimM, sphrPtr + 11*faceLen - padOff); break;
-  case 10: ret = getBottomRightCornerElem_d(k, dimL, dimM, sphrPtr +  8*faceLen - padOff); break;
-  case 11: ret = getBottomRightCornerElem_d(k, dimL, dimM, sphrPtr +  9*faceLen - padOff); break;
+    // facePtr[k*dimL*dimM + dimL*dimM-1];
+  case  8: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 10, k, dimL-p, -1-q); break;
+  case  9: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 11, k, dimL-p, -1-q); break;
+  case 10: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  8, k, dimL-p, -1-q); break;
+  case 11: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  9, k, dimL-p, -1-q); break;
   }
   return ret;
 }
 
-template<typename VAL_T>
+template<typename VAL_T, bool CHANNELS_LAST>
 __global__ void HEALPixPadBck_haloCR_k(const int padSize,
 				       const int dimI,
 				       const int dimJ, // = 12
 				       const int dimK,
 				       const int dimL,
 				       const int dimM,
-				       const VAL_T *__restrict__ vin,
-				       VAL_T *__restrict__ vout) {
+				       const torch::PackedTensorAccessor32<VAL_T, 5, torch::RestrictPtrTraits> vin,
+               torch::PackedTensorAccessor32<VAL_T, 5, torch::RestrictPtrTraits> vout) {
 
   const long long tid = ((long long)blockIdx.x)*blockDim.x + threadIdx.x;
 
@@ -656,38 +611,37 @@ __global__ void HEALPixPadBck_haloCR_k(const int padSize,
   const int dimLI = dimL + 2*padSize;
   const int dimMI = dimM + 2*padSize;
 
-  const long long faceLenI = ((long long)dimK)*dimLI*dimMI;
-  const long long faceLenO = ((long long)dimK)*dimL *dimM;
-
-  const VAL_T *__restrict__ sphrPtrI = vin  +  sphrId*dimJ          *faceLenI;
-  VAL_T *__restrict__ facePtrO = vout + (sphrId*dimJ + faceId)*faceLenO;
-
-  const int k = (tid /  (padSize*padSize)) % dimK;
-  const int p = (tid /           padSize)  % padSize;
-  const int q =  tid                       % padSize;
+  int k, p, q;
+  if constexpr (CHANNELS_LAST) {
+    k =  tid % dimK;
+    p = (tid / dimK)            % padSize;
+    q = (tid / (dimK * padSize)) % padSize;
+  } else {
+    q =  tid % padSize;
+    p = (tid / padSize)            % padSize;
+    k = (tid / (padSize * padSize)) % dimK;
+  }
 
   // copy top-left     corner
+  getElemMutable<VAL_T, CHANNELS_LAST>(vout, sphrId, faceId, k, p, q) += getTL_d<VAL_T, CHANNELS_LAST>(padSize, p, q, k, dimLI, dimMI, faceId, sphrId, vin);
   // copy top-right    corner
+  getElemMutable<VAL_T, CHANNELS_LAST>(vout, sphrId, faceId, k, p, dimM-padSize+q) += getTR_d<VAL_T, CHANNELS_LAST>(padSize, p, q, k, dimLI, dimMI, faceId, sphrId, vin);
   // copy bottom-left  corner
+  getElemMutable<VAL_T, CHANNELS_LAST>(vout, sphrId, faceId, k, dimL-padSize+p, q) += getBL_d<VAL_T, CHANNELS_LAST>(padSize, p, q, k, dimLI, dimMI, faceId, sphrId, vin);
   // copy bottom-right corner
-  facePtrO[k*dimL*dimM                                      + p*dimM + q] += getTL_d(padSize, p, q, k, dimLI, dimMI, faceId, faceLenI, sphrPtrI);
-  facePtrO[k*dimL*dimM                       + dimM-padSize + p*dimM + q] += getTR_d(padSize, p, q, k, dimLI, dimMI, faceId, faceLenI, sphrPtrI);
-  facePtrO[k*dimL*dimM + (dimL-padSize)*dimM                + p*dimM + q] += getBL_d(padSize, p, q, k, dimLI, dimMI, faceId, faceLenI, sphrPtrI);
-  facePtrO[k*dimL*dimM + (dimL-padSize)*dimM + dimM-padSize + p*dimM + q] += getBR_d(padSize, p, q, k, dimLI, dimMI, faceId, faceLenI, sphrPtrI);
+  getElemMutable<VAL_T, CHANNELS_LAST>(vout, sphrId, faceId, k, dimL-padSize+p, dimM-padSize+q) += getBR_d<VAL_T, CHANNELS_LAST>(padSize, p, q, k, dimLI, dimMI, faceId, sphrId, vin);
 
   return;
 }
 
-template<typename REAL_T>
-void HEALPixPadBck(int padSize,
-		   int dimI, // batch size
-		   int dimJ, // 12
-		   int dimK, // no. of channels
-		   int dimL, // face no. of rows of dataOut_d (dataIn_d has dimL+2 rows)
-		   int dimM, // face no. of cols of dataOut_d (dataIn_d has dimM+2 cols)
-		   REAL_T *dataIn_d,
-		   REAL_T *dataOut_d,
-		   cudaStream_t stream) {
+template<typename REAL_T, bool CHANNELS_LAST>
+void HEALPixPadBck(int padSize, torch::Tensor ginput, torch::Tensor goutput, cudaStream_t stream) {
+
+  const int dimI = goutput.size(0);
+  const int dimJ = goutput.size(1);
+  const int dimK = (CHANNELS_LAST ? goutput.size(4) : goutput.size(2));
+  const int dimL = (CHANNELS_LAST ? goutput.size(2) : goutput.size(3));
+  const int dimM = (CHANNELS_LAST ? goutput.size(3) : goutput.size(4));
 
   if (dimI*dimJ*dimK*dimL*dimM <= 0) {
     fprintf(stderr, "%s:%d: error, one or more dimension is less than or equal zero!\n", __func__, __LINE__);
@@ -710,127 +664,93 @@ void HEALPixPadBck(int padSize,
   }
 
   // copy bulk
+  const int W = VecTraits<REAL_T>::LANE_WIDTH;
+  const bool canVec = (((CHANNELS_LAST ? dimK : dimM) & (W-1)) == 0);
   const int nth_b = THREADS;
-  const int nbl_b = DIV_UP(dimI*dimJ*dimK*dimL*dimM, nth_b);
 
-  HEALPixPadBck_bulk_k<<<nbl_b, nth_b, 0, stream>>>(padSize, dimI, dimJ, dimK, dimL, dimM, dataIn_d, dataOut_d);
+  if (canVec) {
+    const int nbl_b = DIV_UP(dimI*dimJ*dimK*dimL*dimM/W, nth_b);
 
-  CHECK_ERROR("HEALPixPad_bck_bulk_k");
+    HEALPixPadBck_bulk_vec_k<REAL_T, CHANNELS_LAST><<<nbl_b, nth_b, 0, stream>>>(padSize, dimI, dimJ, dimK, dimL, dimM,
+                                                      ginput.packed_accessor32<REAL_T, 5, torch::RestrictPtrTraits>(),
+                                                      goutput.packed_accessor32<REAL_T, 5, torch::RestrictPtrTraits>());
 
+    CHECK_ERROR("HEALPixPad_bck_bulk_vec_k");
+  }
+  else {
+    const int nbl_b = DIV_UP(dimI*dimJ*dimK*dimL*dimM, nth_b);
+
+    HEALPixPadBck_bulk_k<REAL_T, CHANNELS_LAST><<<nbl_b, nth_b, 0, stream>>>(padSize, dimI, dimJ, dimK, dimL, dimM,
+                                                      ginput.packed_accessor32<REAL_T, 5, torch::RestrictPtrTraits>(),
+                                                      goutput.packed_accessor32<REAL_T, 5, torch::RestrictPtrTraits>());
+
+    CHECK_ERROR("HEALPixPad_bck_bulk_k");
+  }
   // copy haloes
   const int nth_f = THREADS;
   const int nbl_f = DIV_UP(dimI*dimJ*dimK*dimM*padSize, nth_f);
 
-  HEALPixPadBck_haloTB_k<<<nbl_f, nth_f, 0, stream>>>(padSize, dimI, dimJ, dimK, dimL, dimM, dataIn_d, dataOut_d);
+  HEALPixPadBck_haloTB_k<REAL_T, CHANNELS_LAST><<<nbl_f, nth_f, 0, stream>>>(padSize, dimI, dimJ, dimK, dimL, dimM,
+						      ginput.packed_accessor32<REAL_T, 5, torch::RestrictPtrTraits>(),
+						      goutput.packed_accessor32<REAL_T, 5, torch::RestrictPtrTraits>());
   CHECK_ERROR("HEALPixPadBck_haloTB_k");
-  HEALPixPadBck_haloLR_k<<<nbl_f, nth_f, 0, stream>>>(padSize, dimI, dimJ, dimK, dimL, dimM, dataIn_d, dataOut_d);
+
+  HEALPixPadBck_haloLR_k<REAL_T, CHANNELS_LAST><<<nbl_f, nth_f, 0, stream>>>(padSize, dimI, dimJ, dimK, dimL, dimM,
+						      ginput.packed_accessor32<REAL_T, 5, torch::RestrictPtrTraits>(),
+                                                      goutput.packed_accessor32<REAL_T, 5, torch::RestrictPtrTraits>());
   CHECK_ERROR("HEALPixPadBck_haloLR_k");
 
   const int nth_c = THREADS;
   const int nbl_c = DIV_UP(dimI*dimJ*dimK*padSize*padSize, nth_c);
 
-  HEALPixPadBck_haloCR_k<<<nbl_c, nth_c, 0, stream>>>(padSize, dimI, dimJ, dimK, dimL, dimM, dataIn_d, dataOut_d);
+  HEALPixPadBck_haloCR_k<REAL_T, CHANNELS_LAST><<<nbl_c, nth_c, 0, stream>>>(padSize, dimI, dimJ, dimK, dimL, dimM,
+						      ginput.packed_accessor32<REAL_T, 5, torch::RestrictPtrTraits>(),
+                                                      goutput.packed_accessor32<REAL_T, 5, torch::RestrictPtrTraits>());
 
   CHECK_ERROR("HEALPixPadBck_haloCR_k");
 
-  //CHECK_CUDA(cudaStreamSynchronize(stream));
-
   return;
 }
 
-void HEALPixPad_bwd_fp32(int padSize,
-			 int dimI,
-			 int dimJ,
-			 int dimK,
-			 int dimL,
-			 int dimM,
-			 float *dataIn_d,
-			 float *dataOut_d,
-			 cudaStream_t stream) {
+std::vector<torch::Tensor> healpixpad_cuda_backward(torch::Tensor ginput, int pad, bool channels_last) {
 
-  HEALPixPadBck<float>(padSize, dimI, dimJ, dimK, dimL, dimM, dataIn_d, dataOut_d, stream);
-
-  return;
-}
-
-void HEALPixPad_bwd_fp64(int padSize,
-			 int dimI,
-			 int dimJ,
-			 int dimK,
-			 int dimL,
-			 int dimM,
-			 double *dataIn_d,
-			 double *dataOut_d,
-			 cudaStream_t stream) {
-
-  HEALPixPadBck<double>(padSize, dimI, dimJ, dimK, dimL, dimM, dataIn_d, dataOut_d, stream);
-
-  return;
-}
-
-std::vector<torch::Tensor> healpixpad_cuda_backward(
-						    torch::Tensor ginput,
-						    int pad) {
   const auto batch_size = ginput.size(0);
   const auto num_faces = ginput.size(1);
-  const auto num_channels = ginput.size(2);
+  const auto num_channels = (channels_last ? ginput.size(4) : ginput.size(2));
   // the face size is the size of the output gradient
   const auto face_size = ginput.size(3) - 2*pad;
-  int64_t shape[5] = {batch_size, num_faces, num_channels, face_size, face_size};
 
   // allocate output tensor
-  c10::TensorOptions options = c10::TensorOptions().device(ginput.device()).dtype(ginput.dtype());
-  torch::IntArrayRef size = c10::makeArrayRef<int64_t>(shape, 5);
-  auto goutput = torch::empty(size, options);
+  torch::TensorOptions options = torch::TensorOptions().device(ginput.device()).dtype(ginput.dtype());
+  torch::Tensor goutput;
+  if (!channels_last) {
+    goutput = torch::empty({batch_size, num_faces, num_channels, face_size, face_size}, options);
+  } else {
+    goutput = torch::empty({batch_size, num_faces, face_size, face_size, num_channels}, options);
+  }
 
   // get cuda stream:
-  cudaStream_t my_stream = c10::cuda::getCurrentCUDAStream(ginput.device().index()).stream();
+  auto stream = at::cuda::getCurrentCUDAStream().stream();
 
   switch (ginput.scalar_type()) {
   case torch::ScalarType::Double:
-    HEALPixPadBck<double>(pad,
-			  batch_size,
-			  num_faces,
-			  num_channels,
-			  face_size,
-			  face_size,
-			  ginput.data_ptr<double>(),
-			  goutput.data_ptr<double>(),
-			  my_stream);
+    if (channels_last) HEALPixPadBck<double, true>(pad, ginput, goutput, stream);
+    else HEALPixPadBck<double, false>(pad, ginput, goutput, stream);
     break;
   case torch::ScalarType::Float:
-    HEALPixPadBck<float>(pad,
-			 batch_size,
-			 num_faces,
-			 num_channels,
-			 face_size,
-			 face_size,
-			 ginput.data_ptr<float>(),
-			 goutput.data_ptr<float>(),
-			 my_stream);
+    if (channels_last) HEALPixPadBck<float, true>(pad, ginput, goutput, stream);
+    else HEALPixPadBck<float, false>(pad, ginput, goutput, stream);
     break;
   case torch::ScalarType::Half:
-    HEALPixPadBck<at::Half>(pad,
-			    batch_size,
-			    num_faces,
-			    num_channels,
-			    face_size,
-			    face_size,
-			    ginput.data_ptr<at::Half>(),
-			    goutput.data_ptr<at::Half>(),
-			    my_stream);
+    if (channels_last) HEALPixPadBck<at::Half, true>(pad, ginput, goutput, stream);
+    else HEALPixPadBck<at::Half, false>(pad, ginput, goutput, stream);
     break;
   case torch::ScalarType::BFloat16:
-    HEALPixPadBck<at::BFloat16>(pad,
-			    batch_size,
-			    num_faces,
-			    num_channels,
-			    face_size,
-			    face_size,
-			    ginput.data_ptr<at::BFloat16>(),
-			    goutput.data_ptr<at::BFloat16>(),
-			    my_stream);
+    if (channels_last) HEALPixPadBck<at::BFloat16, true>(pad, ginput, goutput, stream);
+    else HEALPixPadBck<at::BFloat16, false>(pad, ginput, goutput, stream);
     break;
+  default:
+    throw std::invalid_argument("Unsupported datatype for healpixpad_cuda_backward.");
   }
 
   return {goutput};

--- a/earth2grid/csrc/healpixpad/healpixpad_cuda_fwd.cu
+++ b/earth2grid/csrc/healpixpad/healpixpad_cuda_fwd.cu
@@ -2,7 +2,7 @@
  * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Written by Mauro Bisson <maurob@nvidia.com> and THorsten Kurth <tkurth@nvidia.com>
+ * Written by Mauro Bisson <maurob@nvidia.com> and Thorsten Kurth <tkurth@nvidia.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,18 +17,16 @@
  * limitations under the License.
  */
 
+
 #include <torch/extension.h>
-#include <c10/cuda/CUDAStream.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <cuda_runtime.h>
+#include <ATen/cuda/detail/TensorInfo.cuh>
+#include <ATen/cuda/detail/KernelUtils.h>
+#include <ATen/cuda/detail/IndexUtils.cuh>
+#include <ATen/cuda/CUDAUtils.h>
 #include "cudamacro.h"
 #include "healpixpad.h"
 
 #define THREADS  64
-
-#define MIN(x,y) (((x)<(y))?(x):(y))
-#define MAX(x,y) (((x)>(y))?(x):(y))
 
 #define DIV_UP(a,b) (((a)+((b)-1))/(b))
 
@@ -50,15 +48,69 @@
 //
 // Along the k-axis, dimJ=12 faces form a "sphere" and
 // we have in total dimI sphere in the buffers
-template<typename VAL_T>
+
+template<typename VAL_T, bool CHANNELS_LAST>
+__global__ void HEALPixPadFwd_bulk_vec_k(
+        const int padSize,
+        const int dimI, const int dimJ,
+        const int dimK, const int dimL, const int dimM,
+        torch::PackedTensorAccessor32<VAL_T,5,torch::RestrictPtrTraits> vin,
+        torch::PackedTensorAccessor32<VAL_T,5,torch::RestrictPtrTraits> vout)
+{
+  using VecT = typename VecTraits<VAL_T>::VecT;
+  constexpr int W = VecTraits<VAL_T>::LANE_WIDTH;
+
+  const long long tid = blockIdx.x * blockDim.x + threadIdx.x;
+  if (tid >= ((long long)dimI)*dimJ*dimK*dimL*dimM / W) {
+    return;
+  }
+
+  const int dimKVec = CHANNELS_LAST ? dimK / W : dimK;
+  const int dimMVec = CHANNELS_LAST ? dimM : dimM / W;
+
+  int i,j,k,l,m;
+  if constexpr(CHANNELS_LAST) {
+    k = (tid % dimKVec) * W;
+    m = (tid / dimKVec) % dimM;
+    l = (tid / (dimKVec * dimM)) % dimL;
+    j = (tid / (dimKVec * dimM * dimL)) % dimJ;
+    i =  tid / (dimKVec * dimM * dimL * dimJ);
+  } else {
+    m = (tid % dimMVec) * W;
+    l = (tid / dimMVec) % dimL;
+    k = (tid / (dimMVec * dimL)) % dimK;
+    j = (tid / (dimMVec * dimL * dimK)) % dimJ;
+    i =  tid / (dimMVec * dimL * dimK * dimJ);
+  }
+
+  const VecT srcVec = *reinterpret_cast<const VecT*>(
+              &getElem<VAL_T,CHANNELS_LAST>(vin,i,j,k,l,m));
+
+  if (!CHANNELS_LAST && ((padSize & (W - 1)) != 0)) {
+    // Store unvectorized as padding makes output unaligned
+    const VAL_T* lanes = reinterpret_cast<const VAL_T*>(&srcVec);
+  #pragma unroll
+    for (int w = 0; w < W; ++w) {
+        getElemMutable<VAL_T,CHANNELS_LAST>(
+            vout, i, j, k, padSize + l, padSize + m + w) = lanes[w];
+    }
+  } else {
+    // src and dst are both aligned
+    VecT* dstVec = reinterpret_cast<VecT*>(
+      &getElemMutable<VAL_T,CHANNELS_LAST>(vout,i,j,k, padSize+l, padSize+m));
+    *dstVec = srcVec;
+  }
+}
+
+template<typename VAL_T, bool CHANNELS_LAST>
 __global__ void HEALPixPadFwd_bulk_k(const int padSize,
 				     const int dimI,
 				     const int dimJ,
 				     const int dimK,
 				     const int dimL,
 				     const int dimM,
-				     const VAL_T *__restrict__ vin,
-				     VAL_T *__restrict__ vout) {
+				     const torch::PackedTensorAccessor32<VAL_T, 5, torch::RestrictPtrTraits> vin,
+				     torch::PackedTensorAccessor32<VAL_T, 5, torch::RestrictPtrTraits> vout) {
 
   const long long tid = ((long long)blockIdx.x)*blockDim.x + threadIdx.x;
 
@@ -66,239 +118,161 @@ __global__ void HEALPixPadFwd_bulk_k(const int padSize,
     return;
   }
 
-  const long long sliceId = tid / (dimM*dimL);
+  // compute individual indices
+  int i,j,k,l,m;
+  if constexpr(CHANNELS_LAST) {
+    k = tid % dimK;
+    m = (tid / dimK) % dimM;
+    l = (tid / (dimK * dimM)) % dimL;
+    j = (tid / (dimK * dimM * dimL)) % dimJ;
+    i = tid / (dimK * dimM * dimL * dimJ);
+  } else {
+    m = (tid % (dimM*dimL)) % dimM;
+    l = (tid % (dimM*dimL)) / dimM;
+    k = (tid % (dimM*dimL*dimK)) / (dimM*dimL);
+    j = (tid % (dimM*dimL*dimK*dimJ)) / (dimM*dimL*dimK);
+    i = (tid / (dimJ * dimK * dimL * dimM));
+  }
 
-  const int i = (tid % (dimM*dimL)) / dimM;
-  const int j = (tid % (dimM*dimL)) % dimM;
-
-  const int dimLO = dimL + 2*padSize;
-  const int dimMO = dimM + 2*padSize;
-
-  vout[sliceId*dimMO*dimLO + (padSize+i)*dimMO + padSize+j] = vin[sliceId*dimL*dimM + i*dimM + j];
+  // copy data
+  getElemMutable<VAL_T, CHANNELS_LAST>(vout, i, j, k, padSize+l, padSize+m) = getElem<VAL_T, CHANNELS_LAST>(vin, i, j, k, l, m);
 
   return;
 }
 
-// faces functions
-
-template<typename VAL_T>
-__device__ VAL_T getTopFaceElem_d(const int k,
-				  const int m,
-				  const int dimL,
-				  const int dimM,
-				  const VAL_T *__restrict__ facePtr) {
-
-  return facePtr[k*dimL*dimM + m];
-}
-
-template<typename VAL_T>
-__device__ VAL_T getBottomFaceElem_d(const int k,
-				     const int m,
-				     const int dimL,
-				     const int dimM,
-				     const VAL_T *__restrict__ facePtr) {
-
-  return facePtr[k*dimL*dimM + (dimL-1)*dimM + m];
-}
-
-template<typename VAL_T>
-__device__ VAL_T getLeftFaceElem_d(const int k,
-				   const int l,
-				   const int dimL,
-				   const int dimM,
-				   const VAL_T *__restrict__ facePtr) {
-
-  return facePtr[k*dimL*dimM + l*dimM];
-}
-
-template<typename VAL_T>
-__device__ VAL_T getRightFaceElem_d(const int k,
-				    const int l,
-				    const int dimL,
-				    const int dimM,
-				    const VAL_T *__restrict__ facePtr) {
-
-  return facePtr[k*dimL*dimM + l*dimM + dimM-1];
-}
-
-template<typename VAL_T>
+template<typename VAL_T, bool CHANNELS_LAST>
 __device__ VAL_T getT_d(const int k,
 			const int p,
 			const int m,
 			const int dimL,
 			const int dimM,
 			const int faceId,
-			const int faceLen,
-			const VAL_T *__restrict__ sphrPtr) {
+			const int sphrId,
+			const torch::PackedTensorAccessor32<VAL_T, 5, torch::RestrictPtrTraits> sphr) {
 
   VAL_T ret = VAL_T(0);
 
   switch(faceId) {
-    // north faces
-  case  0: ret = getLeftFaceElem_d(k, m, dimL, dimM, sphrPtr + 1*faceLen + p); break;
-  case  1: ret = getLeftFaceElem_d(k, m, dimL, dimM, sphrPtr + 2*faceLen + p); break;
-  case  2: ret = getLeftFaceElem_d(k, m, dimL, dimM, sphrPtr + 3*faceLen + p); break;
-  case  3: ret = getLeftFaceElem_d(k, m, dimL, dimM, sphrPtr + 0*faceLen + p); break;
-    // center faces
-  case  4: ret = getBottomFaceElem_d(k, m, dimL, dimM, sphrPtr + 0*faceLen - p*dimM); break;
-  case  5: ret = getBottomFaceElem_d(k, m, dimL, dimM, sphrPtr + 1*faceLen - p*dimM); break;
-  case  6: ret = getBottomFaceElem_d(k, m, dimL, dimM, sphrPtr + 2*faceLen - p*dimM); break;
-  case  7: ret = getBottomFaceElem_d(k, m, dimL, dimM, sphrPtr + 3*faceLen - p*dimM); break;
-    // south faces
-  case  8: ret = getBottomFaceElem_d(k, m, dimL, dimM, sphrPtr + 5*faceLen - p*dimM); break;
-  case  9: ret = getBottomFaceElem_d(k, m, dimL, dimM, sphrPtr + 6*faceLen - p*dimM); break;
-  case 10: ret = getBottomFaceElem_d(k, m, dimL, dimM, sphrPtr + 7*faceLen - p*dimM); break;
-  case 11: ret = getBottomFaceElem_d(k, m, dimL, dimM, sphrPtr + 4*faceLen - p*dimM); break;
-  }
+      // north faces
+    case  0: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 1, k, m, p); break;
+    case  1: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 2, k, m, p); break;
+    case  2: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 3, k, m, p); break;
+    case  3: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 0, k, m, p); break;
+      // center faces
+    case  4: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 0, k, dimL-1-p, m); break;
+    case  5: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 1, k, dimL-1-p, m); break;
+    case  6: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 2, k, dimL-1-p, m); break;
+    case  7: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 3, k, dimL-1-p, m); break;
+      // south faces
+    case  8: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 5, k, dimL-1-p, m); break;
+    case  9: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 6, k, dimL-1-p, m); break;
+    case 10: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 7, k, dimL-1-p, m); break;
+    case 11: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 4, k, dimL-1-p, m); break;
+    }
+
   return ret;
 }
 
-template<typename VAL_T>
+template<typename VAL_T, bool CHANNELS_LAST>
 __device__ VAL_T getB_d(const int k,
 			const int p,
 			const int m,
 			const int dimL,
 			const int dimM,
 			const int faceId,
-			const int faceLen,
-			const VAL_T *__restrict__ sphrPtr) {
+			const int sphrId,
+			const torch::PackedTensorAccessor32<VAL_T, 5, torch::RestrictPtrTraits> sphr) {
 
   VAL_T ret = VAL_T(0);
 
   switch(faceId) {
-    // north faces
-  case  0: ret = getTopFaceElem_d(k, m, dimL, dimM, sphrPtr + 4*faceLen + p*dimM); break;
-  case  1: ret = getTopFaceElem_d(k, m, dimL, dimM, sphrPtr + 5*faceLen + p*dimM); break;
-  case  2: ret = getTopFaceElem_d(k, m, dimL, dimM, sphrPtr + 6*faceLen + p*dimM); break;
-  case  3: ret = getTopFaceElem_d(k, m, dimL, dimM, sphrPtr + 7*faceLen + p*dimM); break;
-    // center faces
-  case  4: ret = getTopFaceElem_d(k, m, dimL, dimM, sphrPtr + 11*faceLen + p*dimM); break;
-  case  5: ret = getTopFaceElem_d(k, m, dimL, dimM, sphrPtr +  8*faceLen + p*dimM); break;
-  case  6: ret = getTopFaceElem_d(k, m, dimL, dimM, sphrPtr +  9*faceLen + p*dimM); break;
-  case  7: ret = getTopFaceElem_d(k, m, dimL, dimM, sphrPtr + 10*faceLen + p*dimM); break;
-    // south faces
-  case  8: ret = getRightFaceElem_d(k, m, dimL, dimM, sphrPtr + 11*faceLen - p); break;
-  case  9: ret = getRightFaceElem_d(k, m, dimL, dimM, sphrPtr +  8*faceLen - p); break;
-  case 10: ret = getRightFaceElem_d(k, m, dimL, dimM, sphrPtr +  9*faceLen - p); break;
-  case 11: ret = getRightFaceElem_d(k, m, dimL, dimM, sphrPtr + 10*faceLen - p); break;
-  }
+      // north faces
+    case  0: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  4, k, p, m); break;
+    case  1: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  5, k, p, m); break;
+    case  2: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  6, k, p, m); break;
+    case  3: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  7, k, p, m); break;
+      // center faces
+    case  4: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 11, k, p, m); break;
+    case  5: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  8, k, p, m); break;
+    case  6: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  9, k, p, m); break;
+    case  7: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 10, k, p, m); break;
+      // south faces
+    case  8: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 11, k, m, dimM-1-p); break;
+    case  9: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  8, k, m, dimM-1-p); break;
+    case 10: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  9, k, m, dimM-1-p); break;
+    case 11: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 10, k, m, dimM-1-p); break;
+    }
+
   return ret;
 }
 
-template<typename VAL_T>
+template<typename VAL_T, bool CHANNELS_LAST>
 __device__ VAL_T getL_d(const int k,
 			const int p,
 			const int m,
 			const int dimL,
 			const int dimM,
 			const int faceId,
-			const int faceLen,
-			const VAL_T *__restrict__ sphrPtr) {
+			const int sphrId,
+			const torch::PackedTensorAccessor32<VAL_T, 5, torch::RestrictPtrTraits> sphr) {
 
   VAL_T ret = VAL_T(0);
 
-  switch(faceId) {
-    // north faces
-  case  0: ret = getTopFaceElem_d(k, m, dimL, dimM, sphrPtr + 3*faceLen + p*dimM); break;
-  case  1: ret = getTopFaceElem_d(k, m, dimL, dimM, sphrPtr + 0*faceLen + p*dimM); break;
-  case  2: ret = getTopFaceElem_d(k, m, dimL, dimM, sphrPtr + 1*faceLen + p*dimM); break;
-  case  3: ret = getTopFaceElem_d(k, m, dimL, dimM, sphrPtr + 2*faceLen + p*dimM); break;
-    // center faces
-  case  4: ret = getRightFaceElem_d(k, m, dimL, dimM, sphrPtr + 3*faceLen - p); break;
-  case  5: ret = getRightFaceElem_d(k, m, dimL, dimM, sphrPtr + 0*faceLen - p); break;
-  case  6: ret = getRightFaceElem_d(k, m, dimL, dimM, sphrPtr + 1*faceLen - p); break;
-  case  7: ret = getRightFaceElem_d(k, m, dimL, dimM, sphrPtr + 2*faceLen - p); break;
-    // south faces
-  case  8: ret = getRightFaceElem_d(k, m, dimL, dimM, sphrPtr + 4*faceLen - p); break;
-  case  9: ret = getRightFaceElem_d(k, m, dimL, dimM, sphrPtr + 5*faceLen - p); break;
-  case 10: ret = getRightFaceElem_d(k, m, dimL, dimM, sphrPtr + 6*faceLen - p); break;
-  case 11: ret = getRightFaceElem_d(k, m, dimL, dimM, sphrPtr + 7*faceLen - p); break;
-  }
+    switch(faceId) {
+      // north faces
+    case  0: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 3, k, p, m); break;
+    case  1: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 0, k, p, m); break;
+    case  2: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 1, k, p, m); break;
+    case  3: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 2, k, p, m); break;
+      // center faces
+    case  4: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 3, k, m, dimM-1-p); break;
+    case  5: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 0, k, m, dimM-1-p); break;
+    case  6: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 1, k, m, dimM-1-p); break;
+    case  7: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 2, k, m, dimM-1-p); break;
+      // south faces
+    case  8: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 4, k, m, dimM-1-p); break;
+    case  9: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 5, k, m, dimM-1-p); break;
+    case 10: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 6, k, m, dimM-1-p); break;
+    case 11: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 7, k, m, dimM-1-p); break;
+    }
+
   return ret;
 }
 
-template<typename VAL_T>
+  template<typename VAL_T, bool CHANNELS_LAST>
 __device__ VAL_T getR_d(const int k,
 			const int p,
 			const int m,
 			const int dimL,
 			const int dimM,
 			const int faceId,
-			const int faceLen,
-			const VAL_T *__restrict__ sphrPtr) {
+			const int sphrId,
+      const torch::PackedTensorAccessor32<VAL_T, 5, torch::RestrictPtrTraits> sphr) {
 
   VAL_T ret = VAL_T(0);
 
-  switch(faceId) {
-    // north faces
-  case  0: ret = getLeftFaceElem_d(k, m, dimL, dimM, sphrPtr + 5*faceLen + p); break;
-  case  1: ret = getLeftFaceElem_d(k, m, dimL, dimM, sphrPtr + 6*faceLen + p); break;
-  case  2: ret = getLeftFaceElem_d(k, m, dimL, dimM, sphrPtr + 7*faceLen + p); break;
-  case  3: ret = getLeftFaceElem_d(k, m, dimL, dimM, sphrPtr + 4*faceLen + p); break;
-    // center faces
-  case  4: ret = getLeftFaceElem_d(k, m, dimL, dimM, sphrPtr +  8*faceLen + p); break;
-  case  5: ret = getLeftFaceElem_d(k, m, dimL, dimM, sphrPtr +  9*faceLen + p); break;
-  case  6: ret = getLeftFaceElem_d(k, m, dimL, dimM, sphrPtr + 10*faceLen + p); break;
-  case  7: ret = getLeftFaceElem_d(k, m, dimL, dimM, sphrPtr + 11*faceLen + p); break;
-    // south faces
-  case  8: ret = getBottomFaceElem_d(k, m, dimL, dimM, sphrPtr +  9*faceLen - p*dimM); break;
-  case  9: ret = getBottomFaceElem_d(k, m, dimL, dimM, sphrPtr + 10*faceLen - p*dimM); break;
-  case 10: ret = getBottomFaceElem_d(k, m, dimL, dimM, sphrPtr + 11*faceLen - p*dimM); break;
-  case 11: ret = getBottomFaceElem_d(k, m, dimL, dimM, sphrPtr +  8*faceLen - p*dimM); break;
-  }
+    switch(faceId) {
+      // north faces
+    case  0: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  5, k, m, p); break;
+    case  1: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  6, k, m, p); break;
+    case  2: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  7, k, m, p); break;
+    case  3: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  4, k, m, p); break;
+      // center faces
+    case  4: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  8, k, m, p); break;
+    case  5: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  9, k, m, p); break;
+    case  6: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 10, k, m, p); break;
+    case  7: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 11, k, m, p); break;
+      // south faces
+    case  8: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  9, k, dimL-1-p, m); break;
+    case  9: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 10, k, dimL-1-p, m); break;
+    case 10: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 11, k, dimL-1-p, m); break;
+    case 11: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  8, k, dimL-1-p, m); break;
+    }
+
   return ret;
 }
 
-// corners functions
-
-template<typename VAL_T>
-__device__ VAL_T getTopLeftCornerElem_d(const int k,
-					const int dimL,
-					const int dimM,
-					const VAL_T *__restrict__ facePtr) {
-
-  return facePtr[k*dimL*dimM];
-}
-
-template<typename VAL_T>
-__device__ VAL_T getTopRightCornerElem_d(const int k,
-					 const int dimL,
-					 const int dimM,
-					 const VAL_T *__restrict__ facePtr) {
-
-  return facePtr[k*dimL*dimM + dimM-1];
-}
-
-template<typename VAL_T>
-__device__ VAL_T getBottomLeftCornerElem_d(const int k,
-					   const int dimL,
-					   const int dimM,
-					   const VAL_T *__restrict__ facePtr) {
-
-  return facePtr[k*dimL*dimM + (dimL-1)*dimM];
-}
-
-template<typename VAL_T>
-__device__ VAL_T getBottomRightCornerElem_d(const int k,
-					    const int dimL,
-					    const int dimM,
-					    const VAL_T *__restrict__ facePtr) {
-
-  return facePtr[k*dimL*dimM + dimL*dimM-1];
-}
-
-template<typename VAL_T>
-__device__ VAL_T getCombCorner_d(const int k,
-				 const int dimL,
-				 const int dimM,
-				 const VAL_T *__restrict__ facePtr0,
-				 const VAL_T *__restrict__ facePtr1) {
-
-  return (getTopRightCornerElem_d(k, dimL, dimM, facePtr0) +
-	  getBottomLeftCornerElem_d(k, dimL, dimM, facePtr1)) / VAL_T(2);
-}
-
-template<typename VAL_T>
+template<typename VAL_T, bool CHANNELS_LAST>
 __device__ VAL_T getTL_d(const int padSize,
 			 const int p,
 			 const int q,
@@ -306,65 +280,55 @@ __device__ VAL_T getTL_d(const int padSize,
 			 const int dimL,
 			 const int dimM,
 			 const int faceId,
-			 const int faceLen,
-			 const VAL_T *__restrict__ sphrPtr) {
+			 const int sphrId,
+			 const torch::PackedTensorAccessor32<VAL_T, 5, torch::RestrictPtrTraits> sphr) {
 
   VAL_T ret = VAL_T(0);
 
   const int pinv = padSize-1 - p;
   const int qinv = padSize-1 - q;
 
-  // offset from neighbor's corner
-  // for non equatorial faces
-  const int padOff = pinv*dimM + qinv;
-
-  // offsets from neighbors' corners
-  // for equatorial faces (there are
-  // two, one for the left neigh, from
-  // top right corner, and one for
-  // the top neighbor, from the bottom left
-  // corner)
-  const int topRightPadOff   = (p-1 - q)*dimM - qinv;
-  const int bottomLeftPadOff =     -pinv*dimM + (q-1 - p);
-
   switch(faceId) {
     // north faces
-  case  0: ret = getTopLeftCornerElem_d(k, dimL, dimM, sphrPtr + 2*faceLen + padOff); break;
-  case  1: ret = getTopLeftCornerElem_d(k, dimL, dimM, sphrPtr + 3*faceLen + padOff); break;
-  case  2: ret = getTopLeftCornerElem_d(k, dimL, dimM, sphrPtr + 0*faceLen + padOff); break;
-  case  3: ret = getTopLeftCornerElem_d(k, dimL, dimM, sphrPtr + 1*faceLen + padOff); break;
+  case  0: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 2, k, pinv, qinv); break;
+  case  1: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 3, k, pinv, qinv); break;
+  case  2: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 0, k, pinv, qinv); break;
+  case  3: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 1, k, pinv, qinv); break;
     // center faces
   case  4:
   case  5:
   case  6:
   case  7: {
     int srcTRface;
-    int srcBLFace;
+    int srcBLface;
     switch(faceId) {
-    case  4: srcTRface = 3; srcBLFace = 0; break;
-    case  5: srcTRface = 0; srcBLFace = 1; break;
-    case  6: srcTRface = 1; srcBLFace = 2; break;
-    case  7: srcTRface = 2; srcBLFace = 3; break;
+    case  4: srcTRface = 3; srcBLface = 0; break;
+    case  5: srcTRface = 0; srcBLface = 1; break;
+    case  6: srcTRface = 1; srcBLface = 2; break;
+    case  7: srcTRface = 2; srcBLface = 3; break;
     }
     if (p == q)  {
-      ret = getCombCorner_d(k, dimL, dimM,
-			    sphrPtr + srcTRface*faceLen - qinv,
-			    sphrPtr + srcBLFace*faceLen - pinv*dimM);
+      ret = (getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, srcTRface, k, 0, dimM-1-qinv) \
+              + getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, srcBLface, k, dimL-1-pinv, 0)) / VAL_T(2);
       break;
-    } else if (p > q)  { ret =   getTopRightCornerElem_d(k, dimL, dimM, sphrPtr + srcTRface*faceLen + topRightPadOff  ); break;
-    } else  /* p < q*/ { ret = getBottomLeftCornerElem_d(k, dimL, dimM, sphrPtr + srcBLFace*faceLen + bottomLeftPadOff); break;
+    } else if (p > q)  {
+      ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, srcTRface, k, p-1-q, dimM-1-qinv);
+      break;
+    } else  /* p < q*/ {
+      ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, srcBLface, k, dimL-1-pinv, q-1-p);
+      break;
     }
   }
     // south faces
-  case  8: ret = getBottomRightCornerElem_d(k, dimL, dimM, sphrPtr + 0*faceLen - padOff); break;
-  case  9: ret = getBottomRightCornerElem_d(k, dimL, dimM, sphrPtr + 1*faceLen - padOff); break;
-  case 10: ret = getBottomRightCornerElem_d(k, dimL, dimM, sphrPtr + 2*faceLen - padOff); break;
-  case 11: ret = getBottomRightCornerElem_d(k, dimL, dimM, sphrPtr + 3*faceLen - padOff); break;
+  case  8: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 0, k, dimL-pinv, -qinv-1); break;
+  case  9: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 1, k, dimL-pinv, -qinv-1); break;
+  case 10: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 2, k, dimL-pinv, -qinv-1); break;
+  case 11: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 3, k, dimL-pinv, -qinv-1); break;
   }
   return ret;
 }
 
-template<typename VAL_T>
+template<typename VAL_T, bool CHANNELS_LAST>
 __device__ VAL_T getTR_d(const int padSize,
 			 const int p,
 			 const int q,
@@ -372,35 +336,36 @@ __device__ VAL_T getTR_d(const int padSize,
 			 const int dimL,
 			 const int dimM,
 			 const int faceId,
-			 const int faceLen,
-			 const VAL_T *__restrict__ sphrPtr) {
+			 const int sphrId,
+       const torch::PackedTensorAccessor32<VAL_T, 5, torch::RestrictPtrTraits> sphr) {
 
   VAL_T ret = VAL_T(0);
 
   const int pinv = padSize-1 - p;
-  const int padOff = -pinv*dimM + q;
+  //const int padOff = -pinv*dimM + q;
 
   switch(faceId) {
     // north faces
-  case  0: ret = getBottomLeftCornerElem_d(k, dimL, dimM, sphrPtr + 1*faceLen + padOff); break;
-  case  1: ret = getBottomLeftCornerElem_d(k, dimL, dimM, sphrPtr + 2*faceLen + padOff); break;
-  case  2: ret = getBottomLeftCornerElem_d(k, dimL, dimM, sphrPtr + 3*faceLen + padOff); break;
-  case  3: ret = getBottomLeftCornerElem_d(k, dimL, dimM, sphrPtr + 0*faceLen + padOff); break;
+    //facePtr[k*dimL*dimM + (dimL-1)*dimM];
+  case  0: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  1, k, dimL-1-pinv, q); break;
+  case  1: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  2, k, dimL-1-pinv, q); break;
+  case  2: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  3, k, dimL-1-pinv, q); break;
+  case  3: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  0, k, dimL-1-pinv, q); break;
     // center faces
-  case  4: ret = getBottomLeftCornerElem_d(k, dimL, dimM, sphrPtr + 5*faceLen + padOff); break;
-  case  5: ret = getBottomLeftCornerElem_d(k, dimL, dimM, sphrPtr + 6*faceLen + padOff); break;
-  case  6: ret = getBottomLeftCornerElem_d(k, dimL, dimM, sphrPtr + 7*faceLen + padOff); break;
-  case  7: ret = getBottomLeftCornerElem_d(k, dimL, dimM, sphrPtr + 4*faceLen + padOff); break;
+  case  4: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  5, k, dimL-1-pinv, q); break;
+  case  5: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  6, k, dimL-1-pinv, q); break;
+  case  6: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  7, k, dimL-1-pinv, q); break;
+  case  7: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  4, k, dimL-1-pinv, q); break;
     // south faces
-  case  8: ret = getBottomLeftCornerElem_d(k, dimL, dimM, sphrPtr +  9*faceLen + padOff); break;
-  case  9: ret = getBottomLeftCornerElem_d(k, dimL, dimM, sphrPtr + 10*faceLen + padOff); break;
-  case 10: ret = getBottomLeftCornerElem_d(k, dimL, dimM, sphrPtr + 11*faceLen + padOff); break;
-  case 11: ret = getBottomLeftCornerElem_d(k, dimL, dimM, sphrPtr +  8*faceLen + padOff); break;
+  case  8: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  9, k, dimL-1-pinv, q); break;
+  case  9: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 10, k, dimL-1-pinv, q); break;
+  case 10: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 11, k, dimL-1-pinv, q); break;
+  case 11: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  8, k, dimL-1-pinv, q); break;
   }
   return ret;
 }
 
-template<typename VAL_T>
+template<typename VAL_T, bool CHANNELS_LAST>
 __device__ VAL_T getBL_d(int padSize,
 			 const int p,
 			 const int q,
@@ -408,35 +373,34 @@ __device__ VAL_T getBL_d(int padSize,
 			 const int dimL,
 			 const int dimM,
 			 const int faceId,
-			 const int faceLen,
-			 const VAL_T *__restrict__ sphrPtr) {
+			 const int sphrId,
+       const torch::PackedTensorAccessor32<VAL_T, 5, torch::RestrictPtrTraits> sphr) {
 
   VAL_T ret = VAL_T(0);
 
   const int qinv = padSize-1 - q;
-  const int padOff = p*dimM - qinv;
 
   switch(faceId) {
     // north faces
-  case  0: ret = getTopRightCornerElem_d(k, dimL, dimM, sphrPtr + 3*faceLen + padOff); break;
-  case  1: ret = getTopRightCornerElem_d(k, dimL, dimM, sphrPtr + 0*faceLen + padOff); break;
-  case  2: ret = getTopRightCornerElem_d(k, dimL, dimM, sphrPtr + 1*faceLen + padOff); break;
-  case  3: ret = getTopRightCornerElem_d(k, dimL, dimM, sphrPtr + 2*faceLen + padOff); break;
+  case  0: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  3, k, p, dimM-1-qinv); break;
+  case  1: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  0, k, p, dimM-1-qinv); break;
+  case  2: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  1, k, p, dimM-1-qinv); break;
+  case  3: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  2, k, p, dimM-1-qinv); break;
     // center faces
-  case  4: ret = getTopRightCornerElem_d(k, dimL, dimM, sphrPtr + 7*faceLen + padOff); break;
-  case  5: ret = getTopRightCornerElem_d(k, dimL, dimM, sphrPtr + 4*faceLen + padOff); break;
-  case  6: ret = getTopRightCornerElem_d(k, dimL, dimM, sphrPtr + 5*faceLen + padOff); break;
-  case  7: ret = getTopRightCornerElem_d(k, dimL, dimM, sphrPtr + 6*faceLen + padOff); break;
+  case  4: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  7, k, p, dimM-1-qinv); break;
+  case  5: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  4, k, p, dimM-1-qinv); break;
+  case  6: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  5, k, p, dimM-1-qinv); break;
+  case  7: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  6, k, p, dimM-1-qinv); break;
     // south faces
-  case  8: ret = getTopRightCornerElem_d(k, dimL, dimM, sphrPtr + 11*faceLen + padOff); break;
-  case  9: ret = getTopRightCornerElem_d(k, dimL, dimM, sphrPtr +  8*faceLen + padOff); break;
-  case 10: ret = getTopRightCornerElem_d(k, dimL, dimM, sphrPtr +  9*faceLen + padOff); break;
-  case 11: ret = getTopRightCornerElem_d(k, dimL, dimM, sphrPtr + 10*faceLen + padOff); break;
+  case  8: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 11, k, p, dimM-1-qinv); break;
+  case  9: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  8, k, p, dimM-1-qinv); break;
+  case 10: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  9, k, p, dimM-1-qinv); break;
+  case 11: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 10, k, p, dimM-1-qinv); break;
   }
   return ret;
 }
 
-template<typename VAL_T>
+template<typename VAL_T, bool CHANNELS_LAST>
 __device__ VAL_T getBR_d(const int padSize,
 			 const int p,
 			 const int q,
@@ -444,70 +408,60 @@ __device__ VAL_T getBR_d(const int padSize,
 			 const int dimL,
 			 const int dimM,
 			 const int faceId,
-			 const int faceLen,
-			 const VAL_T *__restrict__ sphrPtr) {
+			 const int sphrId,
+       const torch::PackedTensorAccessor32<VAL_T, 5, torch::RestrictPtrTraits> sphr) {
 
   VAL_T ret = VAL_T(0);
 
-  // offset from neighbor's corner
-  // for non equatorial faces
-  const int padOff = p*dimM + q;
-
-  // offsets from neighbors' corners
-  // for equatorial faces (there are
-  // two, one for the bottom neigh, from
-  // top right corner, and one for
-  // the right neighbor, from the bottom left
-  // corner)
-  const int topRightPadOff   =          p*dimM - (p-1 - q);
-  const int bottomLeftPadOff = -(q-1 - p)*dimM + q;
-
   switch(faceId) {
     // north faces
-  case  0: ret = getTopLeftCornerElem_d(k, dimL, dimM, sphrPtr +  8*faceLen + padOff); break;
-  case  1: ret = getTopLeftCornerElem_d(k, dimL, dimM, sphrPtr +  9*faceLen + padOff); break;
-  case  2: ret = getTopLeftCornerElem_d(k, dimL, dimM, sphrPtr + 10*faceLen + padOff); break;
-  case  3: ret = getTopLeftCornerElem_d(k, dimL, dimM, sphrPtr + 11*faceLen + padOff); break;
+  case  0: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  8, k, p, q); break;
+  case  1: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  9, k, p, q); break;
+  case  2: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 10, k, p, q); break;
+  case  3: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 11, k, p, q); break;
     // center faces
   case  4:
   case  5:
   case  6:
   case  7: {
     int srcTRface;
-    int srcBLFace;
+    int srcBLface;
     switch(faceId) {
-    case  4: srcTRface = 11; srcBLFace =  8; break;
-    case  5: srcTRface =  8; srcBLFace =  9; break;
-    case  6: srcTRface =  9; srcBLFace = 10; break;
-    case  7: srcTRface = 10; srcBLFace = 11; break;
+    case  4: srcTRface = 11; srcBLface =  8; break;
+    case  5: srcTRface =  8; srcBLface =  9; break;
+    case  6: srcTRface =  9; srcBLface = 10; break;
+    case  7: srcTRface = 10; srcBLface = 11; break;
     }
     if (p == q)  {
-      ret = getCombCorner_d(k, dimL, dimM,
-			    sphrPtr + srcTRface*faceLen + p*dimM,
-			    sphrPtr + srcBLFace*faceLen + q);
+      ret = (getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, srcTRface, k, p, dimM-1) \
+              + getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, srcBLface, k, dimL-1, q)) / VAL_T(2);
       break;
-    } else if (p > q)  { ret =   getTopRightCornerElem_d(k, dimL, dimM, sphrPtr + srcTRface*faceLen + topRightPadOff  ); break;
-    } else  /* p < q*/ { ret = getBottomLeftCornerElem_d(k, dimL, dimM, sphrPtr + srcBLFace*faceLen + bottomLeftPadOff); break;
+    } else if (p > q)  {
+      ret =  getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, srcTRface, k, p, dimM-(p-q));
+      break;
+    } else  /* p < q*/ {
+      ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, srcBLface, k, dimL-(q-p), q);
+      break;
     }
   }
     // south faces
-  case  8: ret = getBottomRightCornerElem_d(k, dimL, dimM, sphrPtr + 10*faceLen - padOff); break;
-  case  9: ret = getBottomRightCornerElem_d(k, dimL, dimM, sphrPtr + 11*faceLen - padOff); break;
-  case 10: ret = getBottomRightCornerElem_d(k, dimL, dimM, sphrPtr +  8*faceLen - padOff); break;
-  case 11: ret = getBottomRightCornerElem_d(k, dimL, dimM, sphrPtr +  9*faceLen - padOff); break;
+  case  8: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 10, k, dimL-p, -1-q); break;
+  case  9: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId, 11, k, dimL-p, -1-q); break;
+  case 10: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  8, k, dimL-p, -1-q); break;
+  case 11: ret = getElem<VAL_T, CHANNELS_LAST>(sphr, sphrId,  9, k, dimL-p, -1-q); break;
   }
   return ret;
 }
 
-template<typename VAL_T>
+template<typename VAL_T, bool CHANNELS_LAST>
 __global__ void HEALPixPadFwd_haloSD_k(const int padSize,
 				       const int dimI,
 				       const int dimJ,
 				       const int dimK,
 				       const int dimL,
 				       const int dimM,
-				       const VAL_T *__restrict__ vin,
-				       VAL_T *__restrict__ vout) {
+				       const torch::PackedTensorAccessor32<VAL_T, 5, torch::RestrictPtrTraits> input,
+				       torch::PackedTensorAccessor32<VAL_T, 5, torch::RestrictPtrTraits> output) {
 
   const long long tid = ((long long)blockIdx.x)*blockDim.x + threadIdx.x;
 
@@ -521,24 +475,24 @@ __global__ void HEALPixPadFwd_haloSD_k(const int padSize,
   const int dimLO = dimL + 2*padSize;
   const int dimMO = dimM + 2*padSize;
 
-  const long long faceLenI = ((long long)dimK)*dimL *dimM;
-  const long long faceLenO = ((long long)dimK)*dimLO*dimMO;
-
-  const VAL_T *__restrict__ sphrPtrI = vin  +  sphrId*dimJ          *faceLenI;
-  VAL_T *__restrict__ facePtrO = vout + (sphrId*dimJ + faceId)*faceLenO;
-
-  const int k = (tid / (padSize*dimM)) % dimK;
-  const int p = (tid /          dimM)  % padSize;
-  const int m =  tid                   % dimM;
-
+  int k, p, m;
+  if constexpr (CHANNELS_LAST) {
+    k =  tid % dimK;
+    p = (tid / dimK)            % padSize;
+    m = (tid / (dimK * padSize)) % dimM;
+  } else {
+    m =  tid % dimM;
+    p = (tid / dimM)            % padSize;
+    k = (tid / (dimM * padSize)) % dimK;
+  }
   // copy top    face
+  getElemMutable<VAL_T, CHANNELS_LAST>(output, sphrId, faceId, k, padSize-1-p, padSize+m) = getT_d<VAL_T, CHANNELS_LAST>(k, p, m, dimL, dimM, faceId, sphrId, input);
   // copy bottom face
+  getElemMutable<VAL_T, CHANNELS_LAST>(output, sphrId, faceId, k, padSize+dimL+p, padSize+m) = getB_d<VAL_T, CHANNELS_LAST>(k, p, m, dimL, dimM, faceId, sphrId, input);
   // copy left   face
+  getElemMutable<VAL_T, CHANNELS_LAST>(output, sphrId, faceId, k, padSize+m, padSize-1-p) = getL_d<VAL_T, CHANNELS_LAST>(k, p, m, dimL, dimM, faceId, sphrId, input);
   // copy right  face
-  facePtrO[k*dimLO*dimMO + (padSize-   1)*dimMO - p*dimMO + padSize+m] = getT_d(k, p, m, dimL, dimM, faceId, faceLenI, sphrPtrI);
-  facePtrO[k*dimLO*dimMO + (padSize+dimL)*dimMO + p*dimMO + padSize+m] = getB_d(k, p, m, dimL, dimM, faceId, faceLenI, sphrPtrI);
-  facePtrO[k*dimLO*dimMO + (padSize+   m)*dimMO    + padSize-   1 - p] = getL_d(k, p, m, dimL, dimM, faceId, faceLenI, sphrPtrI);
-  facePtrO[k*dimLO*dimMO + (padSize+   m)*dimMO    + padSize+dimM + p] = getR_d(k, p, m, dimL, dimM, faceId, faceLenI, sphrPtrI);
+  getElemMutable<VAL_T, CHANNELS_LAST>(output, sphrId, faceId, k, padSize+m, padSize+dimM+p) = getR_d<VAL_T, CHANNELS_LAST>(k, p, m, dimL, dimM, faceId, sphrId, input);
 
   // padSize is always <= dimM(L)
   // so there are always enough
@@ -546,71 +500,27 @@ __global__ void HEALPixPadFwd_haloSD_k(const int padSize,
   // corners
   if (m < padSize) {
     const int q = m;
-    facePtrO[k*dimLO*dimMO                                         + p*dimMO + q] = getTL_d(padSize, p, q, k, dimL, dimM, faceId, faceLenI, sphrPtrI);
-    facePtrO[k*dimLO*dimMO +                         dimMO-padSize + p*dimMO + q] = getTR_d(padSize, p, q, k, dimL, dimM, faceId, faceLenI, sphrPtrI);
-    facePtrO[k*dimLO*dimMO + (dimLO-padSize)*dimMO                 + p*dimMO + q] = getBL_d(padSize, p, q, k, dimL, dimM, faceId, faceLenI, sphrPtrI);
-    facePtrO[k*dimLO*dimMO + (dimLO-padSize)*dimMO + dimMO-padSize + p*dimMO + q] = getBR_d(padSize, p, q, k, dimL, dimM, faceId, faceLenI, sphrPtrI);
+    getElemMutable<VAL_T, CHANNELS_LAST>(output, sphrId, faceId, k, p, q) = getTL_d<VAL_T, CHANNELS_LAST>(padSize, p, q, k, dimL, dimM, faceId, sphrId, input);
+    getElemMutable<VAL_T, CHANNELS_LAST>(output, sphrId, faceId, k, p, dimMO-padSize+q) = getTR_d<VAL_T, CHANNELS_LAST>(padSize, p, q, k, dimL, dimM, faceId, sphrId, input);
+    getElemMutable<VAL_T, CHANNELS_LAST>(output, sphrId, faceId, k, dimLO-padSize+p, q) = getBL_d<VAL_T, CHANNELS_LAST>(padSize, p, q, k, dimL, dimM, faceId, sphrId, input);
+    getElemMutable<VAL_T, CHANNELS_LAST>(output, sphrId, faceId, k, dimLO-padSize+p, dimMO-padSize+q) = getBR_d<VAL_T, CHANNELS_LAST>(padSize, p, q, k, dimL, dimM, faceId, sphrId, input);
   }
 
   return;
 }
 
-#if 0
-template<typename VAL_T>
-__global__ void HEALPixPadFwd_haloCR_k(const int padSize,
-				       const int dimI,
-				       const int dimJ,
-				       const int dimK,
-				       const int dimL,
-				       const int dimM,
-				       const VAL_T *__restrict__ vin,
-				       VAL_T *__restrict__ vout) {
 
-  const long long tid = ((long long)blockIdx.x)*blockDim.x + threadIdx.x;
-
-  if (tid >= dimI*dimJ*dimK*padSize*padSize) {
-    return;
-  }
-
-  const long long sphrId = tid / (dimJ*dimK*padSize*padSize);
-  const long long faceId = (tid - sphrId*(dimJ*dimK*padSize*padSize)) / (dimK*padSize*padSize);
-
-  const int dimLO = dimL + 2*padSize;
-  const int dimMO = dimM + 2*padSize;
-
-  const long long faceLenI = ((long long)dimK)*dimL *dimM;
-  const long long faceLenO = ((long long)dimK)*dimLO*dimMO;
-
-  const VAL_T *__restrict__ sphrPtrI = vin  +  sphrId*dimJ          *faceLenI;
-  VAL_T *__restrict__ facePtrO = vout + (sphrId*dimJ + faceId)*faceLenO;
-
-  const int k = (tid / (padSize*padSize)) % dimK;
-  const int p = (tid /          padSize)  % padSize;
-  const int q =  tid                      % padSize;
-
-  // copy top-left corner
-  // copy top-right corner
-  // copy bottom-left corner
-  // copy bottom-right corner
-  facePtrO[k*dimLO*dimMO                                         + p*dimMO + q] = getTL_d(padSize, p, q, k, dimL, dimM, faceId, faceLenI, sphrPtrI);
-  facePtrO[k*dimLO*dimMO +                         dimMO-padSize + p*dimMO + q] = getTR_d(padSize, p, q, k, dimL, dimM, faceId, faceLenI, sphrPtrI);
-  facePtrO[k*dimLO*dimMO + (dimLO-padSize)*dimMO                 + p*dimMO + q] = getBL_d(padSize, p, q, k, dimL, dimM, faceId, faceLenI, sphrPtrI);
-  facePtrO[k*dimLO*dimMO + (dimLO-padSize)*dimMO + dimMO-padSize + p*dimMO + q] = getBR_d(padSize, p, q, k, dimL, dimM, faceId, faceLenI, sphrPtrI);
-
-  return;
-}
-#endif
-
-template<typename REAL_T>
+template<typename REAL_T, bool CHANNELS_LAST>
 void HEALPixPadFwd(int padSize,
-		   int dimI,
-		   int dimJ,
-		   int dimK,
-		   int dimL,
-		   int dimM,
-		   REAL_T *dataIn_d,
-		   REAL_T *dataOut_d,
+		   torch::Tensor input,
+		   torch::Tensor output,
 		   cudaStream_t stream) {
+
+  const int dimI = input.size(0);
+  const int dimJ = input.size(1);
+  const int dimK = (CHANNELS_LAST ? input.size(4) : input.size(2));
+  const int dimL = (CHANNELS_LAST ? input.size(2) : input.size(3));
+  const int dimM = (CHANNELS_LAST ? input.size(3) : input.size(4));
 
   if (dimI*dimJ*dimK*dimL*dimM <= 0) {
     fprintf(stderr, "%s:%d: error, one or more dimension is less than or equal zero!\n", __func__, __LINE__);
@@ -632,130 +542,84 @@ void HEALPixPadFwd(int padSize,
     exit(EXIT_FAILURE);
   }
 
+  const int W = VecTraits<REAL_T>::LANE_WIDTH;
+  const bool canVec = (((CHANNELS_LAST ? dimK : dimM) & (W-1)) == 0);
   const int nth_b = THREADS;
-  const int nbl_b = DIV_UP(dimI*dimJ*dimK*dimL*dimM, nth_b);
 
-  HEALPixPadFwd_bulk_k<<<nbl_b, nth_b, 0, stream>>>(padSize, dimI, dimJ, dimK, dimL, dimM, dataIn_d, dataOut_d);
-  CHECK_ERROR("HEALPixPadFwd_bulk_k");
+  if (canVec) {
+    const int nbl_b  = DIV_UP(dimI*dimJ*dimK*dimL*dimM/W, nth_b);
+
+    HEALPixPadFwd_bulk_vec_k<REAL_T,CHANNELS_LAST><<<nbl_b, nth_b, 0, stream>>>(padSize, dimI, dimJ, dimK, dimL, dimM,
+              input.packed_accessor32<REAL_T,5,torch::RestrictPtrTraits>(),
+              output.packed_accessor32<REAL_T,5,torch::RestrictPtrTraits>());
+
+    CHECK_ERROR("HEALPixPadFwd_bulk_vec_k");
+  } else {
+    const int nbl_b  = DIV_UP(dimI*dimJ*dimK*dimL*dimM, nth_b);
+
+    HEALPixPadFwd_bulk_k<REAL_T,CHANNELS_LAST><<<nbl_b, nth_b, 0, stream>>>(padSize, dimI, dimJ, dimK, dimL, dimM,
+              input.packed_accessor32<REAL_T,5,torch::RestrictPtrTraits>(),
+              output.packed_accessor32<REAL_T,5,torch::RestrictPtrTraits>());
+
+    CHECK_ERROR("HEALPixPadFwd_bulk_k");
+  }
 
   // copy haloes
   const int nth_f = THREADS;
   const int nbl_f = DIV_UP(dimI*dimJ*dimK*dimM*padSize, nth_f);
 
   // this also takes care of the corners
-  HEALPixPadFwd_haloSD_k<<<nbl_f, nth_f, 0, stream>>>(padSize, dimI, dimJ, dimK, dimL, dimM, dataIn_d, dataOut_d);
+  REAL_T* dataIn_d = input.data_ptr<REAL_T>();
+  REAL_T* dataOut_d = output.data_ptr<REAL_T>();
+  HEALPixPadFwd_haloSD_k<REAL_T, CHANNELS_LAST><<<nbl_f, nth_f, 0, stream>>>(padSize, dimI, dimJ, dimK, dimL, dimM,
+						      input.packed_accessor32<REAL_T, 5, torch::RestrictPtrTraits>(),
+						      output.packed_accessor32<REAL_T, 5, torch::RestrictPtrTraits>());
+
   CHECK_ERROR("HEALPixPadFwd_haloTB_k");
-  #if 0
-  const int nth_c = THREADS;
-  const int nbl_c = DIV_UP(dimI*dimJ*dimK*padSize*padSize, nth_c);
-
-  HEALPixPadFwd_haloCR_k<<<nbl_c, nth_c, 0, stream>>>(padSize, dimI, dimJ, dimK, dimL, dimM, dataIn_d, dataOut_d);
-  #endif
-  CHECK_ERROR("HEALPixPadFwd_haloCR_k");
-  //CHECK_CUDA(cudaStreamSynchronize(stream));
-
-  return;
-}
-
-void HEALPixPad_fp32(
-		     int padSize,
-		     int dimI,
-		     int dimJ,
-		     int dimK,
-		     int dimL,
-		     int dimM,
-		     float *dataIn_d,
-		     float *dataOut_d,
-		     cudaStream_t stream) {
-
-  HEALPixPadFwd<float>(padSize, dimI, dimJ, dimK, dimL, dimM, dataIn_d, dataOut_d, stream);
-
-  return;
-}
-
-void HEALPixPad_fp64(
-		     int padSize,
-		     int dimI,
-		     int dimJ,
-		     int dimK,
-		     int dimL,
-		     int dimM,
-		     double *dataIn_d,
-		     double *dataOut_d,
-		     cudaStream_t stream) {
-
-  HEALPixPadFwd<double>(padSize, dimI, dimJ, dimK, dimL, dimM, dataIn_d, dataOut_d, stream);
 
   return;
 }
 
 
-std::vector<torch::Tensor> healpixpad_cuda_forward(
-						   torch::Tensor input,
-						   int pad) {
+std::vector<torch::Tensor> healpixpad_cuda_forward(torch::Tensor input, int pad, bool channels_last) {
+
   const auto batch_size = input.size(0);
   const auto num_faces = input.size(1);
-  const auto num_channels = input.size(2);
+  const auto num_channels = (channels_last ? input.size(4) : input.size(2));
   const auto face_size = input.size(3);
-  int64_t shape[5] = {batch_size, num_faces, num_channels, face_size+2*pad, face_size+2*pad};
 
   // allocate output tensor
-  c10::TensorOptions options = c10::TensorOptions().device(input.device()).dtype(input.dtype());
-  torch::IntArrayRef size = c10::makeArrayRef<int64_t>(shape, 5);
-  auto output = torch::empty(size, options);
+  torch::TensorOptions options = torch::TensorOptions().device(input.device()).dtype(input.dtype());
+  torch::Tensor output;
+  if(!channels_last) {
+    output = torch::empty({batch_size, num_faces, num_channels, face_size+2*pad, face_size+2*pad}, options);
+  } else {
+    output = torch::empty({batch_size, num_faces, face_size+2*pad, face_size+2*pad, num_channels}, options);
+  }
 
   // get cuda stream:
-  cudaStream_t my_stream = c10::cuda::getCurrentCUDAStream(input.device().index()).stream();
+  auto stream = at::cuda::getCurrentCUDAStream().stream();
 
+  // call wrapper
   switch (input.scalar_type()) {
   case torch::ScalarType::Double:
-    HEALPixPadFwd<double>(
-			  pad,
-			  batch_size,
-			  num_faces,
-			  num_channels,
-			  face_size,
-			  face_size,
-			  input.data_ptr<double>(),
-			  output.data_ptr<double>(),
-			  my_stream);
+    if (channels_last) HEALPixPadFwd<double, true>(pad, input, output, stream);
+    else HEALPixPadFwd<double, false>(pad, input, output, stream);
     break;
   case torch::ScalarType::Float:
-    HEALPixPadFwd<float>(
-			 pad,
-			 batch_size,
-			 num_faces,
-			 num_channels,
-			 face_size,
-			 face_size,
-			 input.data_ptr<float>(),
-			 output.data_ptr<float>(),
-			 my_stream);
+    if (channels_last) HEALPixPadFwd<float, true>(pad, input, output, stream);
+    else HEALPixPadFwd<float, false>(pad, input, output, stream);
     break;
   case torch::ScalarType::Half:
-    HEALPixPadFwd<at::Half>(
-			    pad,
-			    batch_size,
-			    num_faces,
-			    num_channels,
-			    face_size,
-			    face_size,
-			    input.data_ptr<at::Half>(),
-			    output.data_ptr<at::Half>(),
-			    my_stream);
+    if (channels_last) HEALPixPadFwd<at::Half, true>(pad, input, output, stream);
+    else  HEALPixPadFwd<at::Half, false>(pad, input, output, stream);
     break;
   case torch::ScalarType::BFloat16:
-    HEALPixPadFwd<at::BFloat16>(
-			    pad,
-			    batch_size,
-			    num_faces,
-			    num_channels,
-			    face_size,
-			    face_size,
-			    input.data_ptr<at::BFloat16>(),
-			    output.data_ptr<at::BFloat16>(),
-			    my_stream);
+    if (channels_last) HEALPixPadFwd<at::BFloat16, true>(pad, input, output, stream);
+    else HEALPixPadFwd<at::BFloat16, false>(pad, input, output, stream);
     break;
+  default:
+    throw std::invalid_argument("Unsupported datatype for healpixpad_cuda_forward.");
   }
 
   return {output};

--- a/earth2grid/healpix/_padding/__init__.py
+++ b/earth2grid/healpix/_padding/__init__.py
@@ -48,7 +48,7 @@ def pad_backend(backend: PaddingBackends):
     _backend = old_backend
 
 
-def pad(x: torch.Tensor, padding: int) -> torch.Tensor:
+def pad(x: torch.Tensor, padding: int, channels_last: bool = False) -> torch.Tensor:
     """
     Pad each face consistently with its according neighbors in the HEALPix
 
@@ -56,9 +56,12 @@ def pad(x: torch.Tensor, padding: int) -> torch.Tensor:
         x: The input tensor of shape [N, F, H, W] or [N, F, C, H, W]. Must be
             ordered in HEALPIX_PAD_XY pixel ordering.
         padding: the amount of padding
+        channels_last: whether input is in [N, F, H, W, C] manifest channels last format (for cuda backend only)
 
     Returns:
-        The padded tensor with shape [N, F, H+2*padding, W+2*padding]
+        The tensor padded along the spatial dimensions. For 4D input [N, F, H, W], returns shape [N, F, H+2*padding, W+2*padding].
+        For 5D input, if channels_last=False returns [N, F, C, H+2*padding, W+2*padding],
+        if channels_last=True returns [N, F, H+2*padding, W+2*padding, C].
 
     Examples:
 
@@ -85,6 +88,6 @@ def pad(x: torch.Tensor, padding: int) -> torch.Tensor:
         return pad_python(x, padding)
     elif backend == PaddingBackends.cuda:
         if x.ndim == 5:
-            return cuda._HEALPixPadFunction.apply(x, padding)
+            return cuda._HEALPixPadFunction.apply(x, padding, channels_last)
         else:
-            return cuda._HEALPixPadFunction.apply(x.unsqueeze(2), padding).squeeze(2)
+            return cuda._HEALPixPadFunction.apply(x.unsqueeze(2), padding, channels_last).squeeze(2)


### PR DESCRIPTION
Adds channel last support to the CUDA backend for healpix padding, which is generally more performant than channels first version. Requires a manifest channels last format (B,F,H,W,C) to use. Also adds vectorized load/stores for both the channels first and channels last versions for improved performance.

Example usage:
```
x = torch.randn([n, ntile, nside, nside, nchannels], device="cuda")
with pad_backend(PaddingBackends.cuda):
    out = pad(x, padding=padding, channels_last=True) # shape : (n, ntile, nside+2*padding, nside+2*padding, nchannels)
```