### PR TITLE
Add defaulting pure python backend if no CUDA available

### DIFF
--- a/earth2grid/healpix/_padding/__init__.py
+++ b/earth2grid/healpix/_padding/__init__.py
@@ -34,6 +34,8 @@ class PaddingBackends(Enum):
 # default backend is cuda
 if torch.cuda.is_available() and torch.cuda.device_count() > 0:
     _backend = PaddingBackends.cuda
+else:
+    _backend = PaddingBackends.indexing
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
The change in https://github.com/NVlabs/earth2grid/commit/f1d534bf16870bf12ef1a2d9b13ee5de65d869b7 causes earth2grid to crash if there is no CUDA available. This just adds back the pure python backend if there is no CUDA.