### PR TITLE
Fixing Setup.py for Torch nightly index

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,9 +36,12 @@ def get_compatible_torch_version(version=""):
 
     version = Version(version)
     major, minor, micro = version.release
-    if version.is_prerelease and micro == 0:
+    if version.is_prerelease and micro == 0 and version.pre:
         pre = "".join(map(str, version.pre))
         lower_bound = f">={major}.{minor}.{micro}{pre}"
+    # For supporting torch nightly index
+    elif version.is_prerelease and micro == 0 and version.dev:
+        lower_bound = f">={major}.{minor}.{micro}dev{version.dev}"
     else:
         lower_bound = f">={major}.{minor}"
 


### PR DESCRIPTION
This fixes the torch version function in the setup.py to support using the torch nightly wheels (needed for cuda 13)

The problem was these are marked as pre-release but use a dev tag (so version.pre is actually None), causing an error during build of the package.
https://download.pytorch.org/whl/nightly/torch/

This adds a case to handle dev dependency. This allows me to build earth2grid off a torch nightly install.