### PR TITLE
Doc: Add uv install guide and DCO sign-off instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,19 @@ helps, and credit will always be given.
 
 ## Developer Certificate of Origin
 
+All contributions to this project must be accompanied by a "Sign-off" to
+indicate that the contributor has read and agrees to the Developer
+Certificate of Origin (DCO).
+
+To sign-off on a commit, use the `-s` or `--signoff` flag:
+
+```bash
+git commit -s -m "Commit message"
+```
+
+This will append `Signed-off-by: Your Name <your.email@example.com>` to the
+end of the commit message.
+
 ```
 Developer Certificate of Origin
 Version 1.1

--- a/README.md
+++ b/README.md
@@ -20,7 +20,17 @@ Grids currently supported:
 ## Install
 
 
-## From source (recommended)
+## From source with `uv` (recommended)
+
+If you use [uv](https://github.com/astral-sh/uv), you can set up the development environment with:
+
+```bash
+git clone https://github.com/NVlabs/earth2grid.git
+cd earth2grid
+uv sync --extra all
+```
+
+## From source with `pip`
 
 Pre-requisites:
 - [CUDA Installation that includes cuda compilers](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/)


### PR DESCRIPTION
This PR updates the documentation to improve the developer experience:

1. **uv Installation**: Adds a section to `README.md` for setting up the environment using the `uv` package manager.
2. **DCO Documentation**: Clarifies the commit sign-off process in `CONTRIBUTING.md` to help new contributors satisfy the Developer Certificate of Origin requirements.

